### PR TITLE
[GUILD-2053] - Color change fix

### DIFF
--- a/src/components/[guild]/EditGuild/components/ColorPicker.tsx
+++ b/src/components/[guild]/EditGuild/components/ColorPicker.tsx
@@ -79,7 +79,9 @@ const ColorPicker = ({ fieldName }: Props): JSX.Element => {
           <Input
             maxWidth={40}
             value={pickedColor}
-            onChange={(e) => setValue(fieldName, e.target.value)}
+            onChange={(e) =>
+              setValue(fieldName, e.target.value, { shouldDirty: true })
+            }
             placeholder="Pick a color"
           />
         </HStack>


### PR DESCRIPTION
[Linear issue](https://linear.app/guildxyz/issue/GUILD-2053/guild-color-change-bug)

It didn't work in the case when the color code was typed (or pasted) into the input field. Picking a color with the color picker seemed to work fine

The PR adds a `shouldDIrty: true` to the `setValue` call of the input field's `onChange`, so the value is included in the request