### PR TITLE
[GUILD-2055] - Empty allowlist

### DIFF
--- a/src/requirements/Allowlist/AllowlistForm.tsx
+++ b/src/requirements/Allowlist/AllowlistForm.tsx
@@ -69,15 +69,15 @@ const AllowlistForm = ({ baseFieldPath }: RequirementFormProps): JSX.Element => 
       </FormControl>
 
       <FormControl
-        isRequired
         isInvalid={!!parseFromObject(errors, baseFieldPath)?.data?.addresses}
       >
         <Controller
           control={control}
           name={`${baseFieldPath}.data.addresses` as const}
           rules={{
-            required: "This field is required",
             validate: (value_) => {
+              if (!value_) return
+
               const validAddresses = value_.filter(
                 (address) => address !== "" && isValidAddress(address)
               )


### PR DESCRIPTION
[Linear issue](https://linear.app/guildxyz/issue/GUILD-2055/support-empty-allowlist)

This PR makes the field non-required, so submitting a nullish value is allowed. In this case, the BE will still assign an empty array to `data.addresses`