### PR TITLE
[GUILD-2054] - Role requirement - Guild option fix

### DIFF
--- a/src/requirements/Guild/components/Role.tsx
+++ b/src/requirements/Guild/components/Role.tsx
@@ -5,10 +5,10 @@ import {
   InputGroup,
   InputLeftElement,
 } from "@chakra-ui/react"
+import useGuild from "components/[guild]/hooks/useGuild"
 import ControlledSelect from "components/common/ControlledSelect"
 import FormErrorMessage from "components/common/FormErrorMessage"
 import OptionImage from "components/common/StyledSelect/components/CustomSelectOption/components/OptionImage"
-import useGuild from "components/[guild]/hooks/useGuild"
 import useDebouncedState from "hooks/useDebouncedState"
 import { useEffect, useMemo, useState } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
@@ -59,17 +59,21 @@ const Role = ({ baseFieldPath }: Props): JSX.Element => {
   }, [fetchedGuild])
 
   const mergedGuildOptions = useMemo(() => {
-    if (!guildOptions) return []
+    if (!guildOptions && !foundGuild) return []
 
-    if (foundGuild && !guildOptions?.find((g) => g.value === foundGuild.id))
-      return [
-        ...guildOptions,
-        {
+    const foundGuildOption = foundGuild
+      ? {
           img: foundGuild.imageUrl,
           label: foundGuild.name,
           value: foundGuild.id,
-        },
-      ]
+          details: foundGuild.urlName,
+        }
+      : null
+
+    if (foundGuild && !guildOptions) return [foundGuildOption]
+
+    if (foundGuild && !guildOptions?.find((g) => g.value === foundGuild.id))
+      return [...guildOptions, foundGuildOption]
 
     return guildOptions
   }, [guildOptions, foundGuild])


### PR DESCRIPTION
[Linear issue](https://linear.app/guildxyz/issue/GUILD-2054/guild-role-requirement-ui-bug)

This PR adds a new case to the `mergedGuildOptions` `useMemo`, which is when the search result is still being fetched, but the `foundGuild` value is truthy, which fixes a small glitch if we search for a guild, which the `foundGuild` already has