### PR TITLE
[GUILD-2058] - Role image upload save button fix

### DIFF
--- a/src/components/[guild]/RoleCard/components/EditRole/EditRole.tsx
+++ b/src/components/[guild]/RoleCard/components/EditRole/EditRole.tsx
@@ -265,7 +265,7 @@ const EditRole = ({ roleId }: Props): JSX.Element => {
           </DrawerBody>
 
           <AnimatePresence>
-            {isDirty && (
+            {(isDirty || iconUploader.isUploading) && (
               <MotionDrawerFooter
                 initial={{ y: FOOTER_OFFSET, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}


### PR DESCRIPTION
[Linear issue](https://linear.app/guildxyz/issue/GUILD-2058/role-edit-drawer-save-button-bug)

The image change was only detected when the upload was finished, so there was a small delay between starting the upload and showing the save button. Since the save button handles the awaiting of the image upload, it seemed enough to just also show the footer when an upload is in progress