### PR TITLE
[GUILD-2074] - Fix GitHub reauth alert

### DIFF
--- a/src/components/[guild]/JoinModal/hooks/useConnectPlatform.ts
+++ b/src/components/[guild]/JoinModal/hooks/useConnectPlatform.ts
@@ -122,7 +122,12 @@ const useConnect = (onSuccess?: () => void, isAutoConnect = false) => {
       mutateUser(
         (prev) => ({
           ...prev,
-          platformUsers: [...(prev?.platformUsers ?? []), newPlatformUser],
+          platformUsers: [
+            ...(prev?.platformUsers ?? []).filter(
+              ({ platformId }) => platformId !== newPlatformUser.platformId
+            ),
+            newPlatformUser,
+          ],
         }),
         { revalidate: false }
       )

--- a/src/components/common/GitHubGuildSetup.tsx
+++ b/src/components/common/GitHubGuildSetup.tsx
@@ -57,7 +57,7 @@ const GitHubGuildSetup = ({
         </Box>
 
         <SimpleGrid columns={{ base: 1, md: 2 }} spacing={{ base: 4, md: 5 }}>
-          {[...Array(9)].map((i) => (
+          {[...Array(9)].map((_, i) => (
             <GridItem key={i}>
               <RepoSkeletonCard />
             </GridItem>
@@ -111,8 +111,8 @@ const GitHubGuildSetup = ({
           <Link passHref href="https://github.com/new">
             <Button as="a" target={"_blank"} variant="link">
               create one
-          </Button>
-        </Link>
+            </Button>
+          </Link>
           , then return here to gate access to it!
         </AlertDescription>
       </VStack>

--- a/src/components/create-guild/MultiPlatformGrid/components/MultiPlatformSelectButton.tsx
+++ b/src/components/create-guild/MultiPlatformGrid/components/MultiPlatformSelectButton.tsx
@@ -84,7 +84,10 @@ const MultiPlatformSelectButton = ({
 
   const { onConnect, isLoading, loadingText } = useConnectPlatform(
     platform,
-    () => onSelection(platform),
+    () => {
+      onOpen()
+      onSelection(platform)
+    },
     false,
     "creation"
   )


### PR DESCRIPTION
[Linear issue](https://linear.app/guildxyz/issue/GUILD-2074/github-guild-creation-fix-wrong-scope-error)

- Since there is no exact way to tell if a reauth is needed, or the user simply doesn't have any repos, this PR modifies the error alert to account for both cases
- There are three minor bugs I've found on the way:
  - The skeleton's `key` values were wrong, I believe they all were undefined, instead of the intended index values
  - When selecting a platform on the create-guild page, the modal didn't open when a platform connection also happened
  - The user SWR state contained invalid data when a reauth happened, because the mutation just appended the platformUser object to the array