### PR TITLE
fix(GuildTabs): debug&fix "/undefined" page

### DIFF
--- a/src/components/[guild]/Tabs/GuildTabs.tsx
+++ b/src/components/[guild]/Tabs/GuildTabs.tsx
@@ -28,7 +28,11 @@ const GuildTabs = ({ activeTab, ...rest }: Props): JSX.Element => {
 
   return (
     <Tabs {...rest}>
-      <TabButton href={`/${urlName}`} isActive={activeTab === "HOME"}>
+      <TabButton
+        href={`/${urlName}`}
+        isActive={activeTab === "HOME"}
+        isLoading={!urlName}
+      >
         Home
       </TabButton>
 

--- a/src/components/[guild]/Tabs/GuildTabs.tsx
+++ b/src/components/[guild]/Tabs/GuildTabs.tsx
@@ -28,11 +28,7 @@ const GuildTabs = ({ activeTab, ...rest }: Props): JSX.Element => {
 
   return (
     <Tabs {...rest}>
-      <TabButton
-        href={`/${urlName}`}
-        isActive={activeTab === "HOME"}
-        isLoading={!urlName}
-      >
+      <TabButton href={`/${urlName}`} isActive={activeTab === "HOME"}>
         Home
       </TabButton>
 


### PR DESCRIPTION
The navigation home tab from events tab when fetching the events was failed or not done causes navigation to the guild.xyz/undefined guild page.