### PR TITLE
feat: create superadmin activity log page

### DIFF
--- a/src/components/[guild]/activity/ActivityLogAction/components/ActionLabel.tsx
+++ b/src/components/[guild]/activity/ActivityLogAction/components/ActionLabel.tsx
@@ -13,7 +13,7 @@ import { ClickableUserTag } from "./UserTag"
 
 const ActionLabel = (): JSX.Element => {
   const { data: activityLog, activityLogType } = useActivityLog()
-  const isUserActivityLog = activityLogType === "user"
+  const showGuildTag = activityLogType === "user" || activityLogType === "all"
 
   const { action, ids, data, parentId } = useActivityLogActionContext()
 
@@ -32,7 +32,7 @@ const ActionLabel = (): JSX.Element => {
             return (
               <>
                 <Text as="span">{capitalizedName}</Text>
-                {isUserActivityLog ? (
+                {showGuildTag ? (
                   <ClickableGuildTag guildId={ids.guild} />
                 ) : (
                   <>
@@ -46,7 +46,7 @@ const ActionLabel = (): JSX.Element => {
             return (
               <>
                 <Text as="span">{capitalizedName}</Text>
-                {isUserActivityLog ? (
+                {showGuildTag ? (
                   <ClickableGuildTag guildId={ids.guild} />
                 ) : (
                   <>
@@ -69,7 +69,7 @@ const ActionLabel = (): JSX.Element => {
               <>
                 <Text as="span">{capitalizedName}:</Text>
                 <ClickableUserTag userId={ids.user} />
-                {isUserActivityLog && <ClickableGuildTag guildId={ids.guild} />}
+                {showGuildTag && <ClickableGuildTag guildId={ids.guild} />}
               </>
             )
           case ACTION.CreateRole:
@@ -79,7 +79,7 @@ const ActionLabel = (): JSX.Element => {
               <>
                 <Text as="span">{capitalizedName}</Text>
                 <ClickableRoleTag roleId={ids.role} guildId={ids.guild} />
-                {isUserActivityLog ? (
+                {showGuildTag ? (
                   <ClickableGuildTag guildId={ids.guild} />
                 ) : (
                   <>
@@ -154,7 +154,7 @@ const ActionLabel = (): JSX.Element => {
             return (
               <>
                 <Text as="span">Join Guild through website</Text>
-                {isUserActivityLog ? (
+                {showGuildTag ? (
                   <ClickableGuildTag guildId={ids.guild} />
                 ) : (
                   <ClickableUserTag userId={ids.user} />
@@ -167,7 +167,7 @@ const ActionLabel = (): JSX.Element => {
                 <Text as="span">{`Join Guild through ${
                   platforms[data.platformName].name
                 }`}</Text>
-                {isUserActivityLog ? (
+                {showGuildTag ? (
                   <ClickableGuildTag guildId={ids.guild} />
                 ) : (
                   <ClickableUserTag userId={ids.user} />
@@ -180,7 +180,7 @@ const ActionLabel = (): JSX.Element => {
             return (
               <>
                 <Text as="span">{capitalizedName}</Text>
-                {isUserActivityLog ? (
+                {showGuildTag ? (
                   <ClickableGuildTag guildId={ids.guild} />
                 ) : (
                   <ClickableUserTag userId={ids.user} />
@@ -234,7 +234,7 @@ const ActionLabel = (): JSX.Element => {
                   platformName={data.platformName}
                   username={data.username}
                 />
-                {!isUserActivityLog && <ClickableUserTag userId={ids.user} />}
+                {activityLogType != "user" && <ClickableUserTag userId={ids.user} />}
               </>
             )
 

--- a/src/components/[guild]/activity/ActivityLogAction/components/ActionLabel.tsx
+++ b/src/components/[guild]/activity/ActivityLogAction/components/ActionLabel.tsx
@@ -12,7 +12,8 @@ import { ClickableRewardTag } from "./RewardTag"
 import { ClickableUserTag } from "./UserTag"
 
 const ActionLabel = (): JSX.Element => {
-  const { data: activityLog, isUserActivityLog } = useActivityLog()
+  const { data: activityLog, activityLogType } = useActivityLog()
+  const isUserActivityLog = activityLogType === "user"
 
   const { action, ids, data, parentId } = useActivityLogActionContext()
 

--- a/src/components/[guild]/activity/ActivityLogAction/components/ClickableTagPopover/components/ViewInCRM.tsx
+++ b/src/components/[guild]/activity/ActivityLogAction/components/ClickableTagPopover/components/ViewInCRM.tsx
@@ -1,6 +1,6 @@
-import Button from "components/common/Button"
 import { useActivityLog } from "components/[guild]/activity/ActivityLogContext"
 import useGuild from "components/[guild]/hooks/useGuild"
+import Button from "components/common/Button"
 import { useRouter } from "next/router"
 import { ArrowSquareOut } from "phosphor-react"
 
@@ -14,9 +14,9 @@ const ViewInCRM = ({ label, queryKey, queryValue }: Props): JSX.Element => {
   const router = useRouter()
   const { urlName, featureFlags } = useGuild()
   const isCRMDisabled = !featureFlags?.includes("CRM")
-  const { isUserActivityLog } = useActivityLog()
+  const { activityLogType } = useActivityLog()
 
-  if (isUserActivityLog) return null
+  if (activityLogType === "user") return null
 
   return (
     <Button

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/ActivityLogFiltersContext.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/ActivityLogFiltersContext.tsx
@@ -176,6 +176,7 @@ const ActivityLogFiltersProvider = ({
 
   useEffect(() => {
     if (
+      !router.pathname.includes("/superadmin") &&
       !router.pathname.includes("/profile") &&
       (!query.guild || !Object.keys(prevQuery ?? {}).length)
     )

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/DateRangeInput.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/DateRangeInput.tsx
@@ -35,7 +35,8 @@ const DateRangeInput = ({ ...chakraStyles }) => {
   const buttonBgColor = useColorModeValue("white", "blackAlpha.300")
   const isMobile = useBreakpointValue({ base: true, md: false })
 
-  const { isUserActivityLog } = useActivityLog()
+  const { activityLogType } = useActivityLog()
+
   const { activeFilters, addFilter, updateFilter, removeFilter } =
     useActivityLogFilters()
   const beforeFilter = activeFilters?.find(({ filter }) => filter === "before")
@@ -81,7 +82,7 @@ const DateRangeInput = ({ ...chakraStyles }) => {
       : afterInputValue
       ? `After ${afterInputValue}`
       : // TODO: if CRM is enabled, we should display "Last 30 days"
-      isUserActivityLog
+      activityLogType === "user"
       ? "Last 30 days"
       : "Last 24 hours"
 

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/FilterTag.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/FilterTag.tsx
@@ -328,7 +328,6 @@ const FilterTag = ({
                 case "roleId":
                   return (
                     <RoleSuggestions
-                      guildId={guildId}
                       inputValue={inputValue}
                       getOptionProps={getOptionProps}
                     />

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/FilterTag.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/FilterTag.tsx
@@ -307,53 +307,53 @@ const FilterTag = ({
         )}
       </Tag>
 
-      {["guildId", "roleId", "rolePlatformId", "action"].includes(filter) && (
-        <Dropdown
-          {...{
-            ...positionerProps,
-            style: { ...positionerProps.style, ...positionerStyle },
-          }}
-        >
-          <Stack spacing={0} {...contentProps}>
-            {(() => {
-              switch (filter) {
-                case "guildId":
-                  if (isSuperadminActivityLog) return <></>
-                  return (
-                    <GuildSuggestions
-                      inputValue={inputValue}
-                      getOptionProps={getOptionProps}
-                    />
-                  )
-                case "roleId":
-                  return (
-                    <RoleSuggestions
-                      inputValue={inputValue}
-                      getOptionProps={getOptionProps}
-                    />
-                  )
-                case "rolePlatformId":
-                  return (
-                    <RewardSuggestions
-                      guildId={guildId}
-                      inputValue={inputValue}
-                      getOptionProps={getOptionProps}
-                    />
-                  )
-                case "action":
-                  return (
-                    <ActionSuggestons
-                      inputValue={inputValue}
-                      getOptionProps={getOptionProps}
-                    />
-                  )
-                default:
-                  return null
-              }
-            })()}
-          </Stack>
-        </Dropdown>
-      )}
+      {["guildId", "roleId", "rolePlatformId", "action"].includes(filter) &&
+        !(isSuperadminActivityLog && filter == "guildId") && (
+          <Dropdown
+            {...{
+              ...positionerProps,
+              style: { ...positionerProps.style, ...positionerStyle },
+            }}
+          >
+            <Stack spacing={0} {...contentProps}>
+              {(() => {
+                switch (filter) {
+                  case "guildId":
+                    return (
+                      <GuildSuggestions
+                        inputValue={inputValue}
+                        getOptionProps={getOptionProps}
+                      />
+                    )
+                  case "roleId":
+                    return (
+                      <RoleSuggestions
+                        inputValue={inputValue}
+                        getOptionProps={getOptionProps}
+                      />
+                    )
+                  case "rolePlatformId":
+                    return (
+                      <RewardSuggestions
+                        guildId={guildId}
+                        inputValue={inputValue}
+                        getOptionProps={getOptionProps}
+                      />
+                    )
+                  case "action":
+                    return (
+                      <ActionSuggestons
+                        inputValue={inputValue}
+                        getOptionProps={getOptionProps}
+                      />
+                    )
+                  default:
+                    return null
+                }
+              })()}
+            </Stack>
+          </Dropdown>
+        )}
     </>
   )
 }

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/FilterTag.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/FilterTag.tsx
@@ -328,6 +328,7 @@ const FilterTag = ({
                   case "roleId":
                     return (
                       <RoleSuggestions
+                        guildId={guildId}
                         inputValue={inputValue}
                         getOptionProps={getOptionProps}
                       />

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RewardSuggestions.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RewardSuggestions.tsx
@@ -3,6 +3,7 @@ import RewardTag from "components/[guild]/activity/ActivityLogAction/components/
 import useGuild from "components/[guild]/hooks/useGuild"
 import { HTMLAttributes, useMemo } from "react"
 import { PlatformName, PlatformType } from "types"
+import { useActivityLogFilters } from "../../ActivityLogFiltersContext"
 import Suggestion from "../../Suggestion"
 import NoResults from "./NoResults"
 
@@ -12,11 +13,9 @@ type Props = {
   getOptionProps: (props: combobox.OptionProps) => HTMLAttributes<HTMLElement>
 }
 
-const RewardSuggestions = ({
-  guildId,
-  inputValue,
-  getOptionProps,
-}: Props): JSX.Element => {
+const RewardSuggestions = ({ inputValue, getOptionProps }: Props): JSX.Element => {
+  const { activeFilters } = useActivityLogFilters()
+  const guildId = activeFilters?.find((af) => af.filter === "guildId")?.value
   const { roles, guildPlatforms } = useGuild(guildId)
 
   const allRewardSuggestions = useMemo(

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RewardSuggestions.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RewardSuggestions.tsx
@@ -3,7 +3,6 @@ import RewardTag from "components/[guild]/activity/ActivityLogAction/components/
 import useGuild from "components/[guild]/hooks/useGuild"
 import { HTMLAttributes, useMemo } from "react"
 import { PlatformName, PlatformType } from "types"
-import { useActivityLogFilters } from "../../ActivityLogFiltersContext"
 import Suggestion from "../../Suggestion"
 import NoResults from "./NoResults"
 
@@ -13,9 +12,11 @@ type Props = {
   getOptionProps: (props: combobox.OptionProps) => HTMLAttributes<HTMLElement>
 }
 
-const RewardSuggestions = ({ inputValue, getOptionProps }: Props): JSX.Element => {
-  const { activeFilters } = useActivityLogFilters()
-  const guildId = activeFilters?.find((af) => af.filter === "guildId")?.value
+const RewardSuggestions = ({
+  guildId,
+  inputValue,
+  getOptionProps,
+}: Props): JSX.Element => {
   const { roles, guildPlatforms } = useGuild(guildId)
 
   const allRewardSuggestions = useMemo(

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RewardSuggestions.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RewardSuggestions.tsx
@@ -7,12 +7,17 @@ import Suggestion from "../../Suggestion"
 import NoResults from "./NoResults"
 
 type Props = {
+  guildId?: string | number
   inputValue?: string
   getOptionProps: (props: combobox.OptionProps) => HTMLAttributes<HTMLElement>
 }
 
-const RewardSuggestions = ({ inputValue, getOptionProps }: Props): JSX.Element => {
-  const { roles, guildPlatforms } = useGuild()
+const RewardSuggestions = ({
+  guildId,
+  inputValue,
+  getOptionProps,
+}: Props): JSX.Element => {
+  const { roles, guildPlatforms } = useGuild(guildId)
 
   const allRewardSuggestions = useMemo(
     () =>

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RoleSuggestions.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RoleSuggestions.tsx
@@ -6,12 +6,17 @@ import Suggestion from "../../Suggestion"
 import NoResults from "./NoResults"
 
 type Props = {
+  guildId?: string | number
   inputValue?: string
   getOptionProps: (props: combobox.OptionProps) => HTMLAttributes<HTMLElement>
 }
 
-const RoleSuggestions = ({ inputValue, getOptionProps }: Props): JSX.Element => {
-  const { id: guildId, roles } = useGuild()
+const RoleSuggestions = ({
+  guildId,
+  inputValue,
+  getOptionProps,
+}: Props): JSX.Element => {
+  const { roles } = useGuild(guildId)
 
   const roleSuggestions = useMemo(
     () =>
@@ -42,7 +47,10 @@ const RoleSuggestions = ({ inputValue, getOptionProps }: Props): JSX.Element => 
                 value: roleSuggestion.id.toString(),
               })}
             >
-              <ActivityLogRoleTag roleId={roleSuggestion.id} guildId={guildId} />
+              <ActivityLogRoleTag
+                roleId={roleSuggestion.id}
+                guildId={guildId as number}
+              />
             </Suggestion>
           )
         })

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RoleSuggestions.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RoleSuggestions.tsx
@@ -2,7 +2,6 @@ import * as combobox from "@zag-js/combobox"
 import ActivityLogRoleTag from "components/[guild]/activity/ActivityLogAction/components/ActivityLogRoleTag"
 import useGuild from "components/[guild]/hooks/useGuild"
 import { HTMLAttributes, useMemo } from "react"
-import { useActivityLogFilters } from "../../ActivityLogFiltersContext"
 import Suggestion from "../../Suggestion"
 import NoResults from "./NoResults"
 
@@ -12,10 +11,11 @@ type Props = {
   getOptionProps: (props: combobox.OptionProps) => HTMLAttributes<HTMLElement>
 }
 
-const RoleSuggestions = ({ inputValue, getOptionProps }: Props): JSX.Element => {
-  const { activeFilters } = useActivityLogFilters()
-  const guildId = activeFilters?.find((af) => af.filter === "guildId")?.value
-
+const RoleSuggestions = ({
+  guildId,
+  inputValue,
+  getOptionProps,
+}: Props): JSX.Element => {
   const { roles } = useGuild(guildId)
 
   const roleSuggestions = useMemo(

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RoleSuggestions.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FilterTag/components/RoleSuggestions.tsx
@@ -2,6 +2,7 @@ import * as combobox from "@zag-js/combobox"
 import ActivityLogRoleTag from "components/[guild]/activity/ActivityLogAction/components/ActivityLogRoleTag"
 import useGuild from "components/[guild]/hooks/useGuild"
 import { HTMLAttributes, useMemo } from "react"
+import { useActivityLogFilters } from "../../ActivityLogFiltersContext"
 import Suggestion from "../../Suggestion"
 import NoResults from "./NoResults"
 
@@ -11,11 +12,10 @@ type Props = {
   getOptionProps: (props: combobox.OptionProps) => HTMLAttributes<HTMLElement>
 }
 
-const RoleSuggestions = ({
-  guildId,
-  inputValue,
-  getOptionProps,
-}: Props): JSX.Element => {
+const RoleSuggestions = ({ inputValue, getOptionProps }: Props): JSX.Element => {
+  const { activeFilters } = useActivityLogFilters()
+  const guildId = activeFilters?.find((af) => af.filter === "guildId")?.value
+
   const { roles } = useGuild(guildId)
 
   const roleSuggestions = useMemo(
@@ -49,7 +49,7 @@ const RoleSuggestions = ({
             >
               <ActivityLogRoleTag
                 roleId={roleSuggestion.id}
-                guildId={guildId as number}
+                guildId={Number(guildId)}
               />
             </Suggestion>
           )

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FiltersInput.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FiltersInput.tsx
@@ -181,11 +181,7 @@ const FiltersInput = (): JSX.Element => {
         </HStack>
       </Box>
       <Dropdown ref={positionerRef} {...positionerProps}>
-        <Suggestions
-          contentProps={contentProps}
-          activeFilters={activeFilters}
-          getOptionProps={getOptionProps}
-        />
+        <Suggestions contentProps={contentProps} getOptionProps={getOptionProps} />
       </Dropdown>
     </>
   )

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FiltersInput.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FiltersInput.tsx
@@ -3,8 +3,6 @@ import {
   HStack,
   IconButton,
   Input,
-  Stack,
-  Text,
   useColorModeValue,
   Wrap,
 } from "@chakra-ui/react"
@@ -12,16 +10,15 @@ import * as combobox from "@zag-js/combobox"
 import { normalizeProps, useMachine } from "@zag-js/react"
 import { CaretDown, X } from "phosphor-react"
 import { KeyboardEvent, useEffect, useRef, useState } from "react"
-import { useActivityLog } from "../../ActivityLogContext"
 import {
   isSupportedQueryParam,
-  SupportedSearchOption,
   SUPPORTED_SEARCH_OPTIONS,
+  SupportedSearchOption,
   useActivityLogFilters,
 } from "./ActivityLogFiltersContext"
 import Dropdown from "./Dropdown"
 import FilterTag from "./FilterTag"
-import Suggestion from "./Suggestion"
+import Suggestions from "./Suggestions"
 
 const getPositionerCSSVariables = (
   element: HTMLDivElement
@@ -33,8 +30,6 @@ const getPositionerCSSVariables = (
 }
 
 const FiltersInput = (): JSX.Element => {
-  const { isUserActivityLog } = useActivityLog()
-
   const rootBgColor = useColorModeValue("white", "blackAlpha.300")
 
   const { activeFilters, addFilter, removeLastFilter, clearFilters } =
@@ -115,13 +110,6 @@ const FiltersInput = (): JSX.Element => {
       setPositionerStyle(rawPositionerStyle)
   }, [rawPositionerStyle.transform])
 
-  const shouldRenderRoleSuggestions =
-    !isUserActivityLog && !activeFilters?.some((af) => af.filter === "roleId")
-
-  const shouldRenderRewardSuggestions =
-    !isUserActivityLog &&
-    !activeFilters?.some((af) => af.filter === "rolePlatformId")
-
   return (
     <>
       <Box
@@ -187,60 +175,11 @@ const FiltersInput = (): JSX.Element => {
         </HStack>
       </Box>
       <Dropdown ref={positionerRef} {...positionerProps}>
-        <Stack spacing={0} {...contentProps}>
-          {!isUserActivityLog && (
-            <Suggestion
-              label="User"
-              {...getOptionProps({ label: "User", value: "userId" })}
-            >
-              <Text as="span" colorScheme="gray" fontWeight="normal" noOfLines={1}>
-                Filter by wallet addresses
-              </Text>
-            </Suggestion>
-          )}
-
-          {isUserActivityLog && (
-            <Suggestion
-              label="Guild"
-              {...getOptionProps({ label: "Guild", value: "guildId" })}
-            >
-              <Text as="span" colorScheme="gray" fontWeight="normal" noOfLines={1}>
-                Filter by guild
-              </Text>
-            </Suggestion>
-          )}
-
-          {shouldRenderRoleSuggestions && (
-            <Suggestion
-              label="Role"
-              {...getOptionProps({ label: "Role", value: "roleId" })}
-            >
-              <Text as="span" colorScheme="gray" fontWeight="normal" noOfLines={1}>
-                Filter by role
-              </Text>
-            </Suggestion>
-          )}
-
-          {shouldRenderRewardSuggestions && (
-            <Suggestion
-              label="Reward"
-              {...getOptionProps({ label: "Reward", value: "rolePlatformId" })}
-            >
-              <Text as="span" colorScheme="gray" fontWeight="normal" noOfLines={1}>
-                Filter by reward
-              </Text>
-            </Suggestion>
-          )}
-
-          <Suggestion
-            label="Action"
-            {...getOptionProps({ label: "Action", value: "action" })}
-          >
-            <Text as="span" colorScheme="gray" fontWeight="normal" noOfLines={1}>
-              Filter by action
-            </Text>
-          </Suggestion>
-        </Stack>
+        <Suggestions
+          contentProps={contentProps}
+          activeFilters={activeFilters}
+          getOptionProps={getOptionProps}
+        />
       </Dropdown>
     </>
   )

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/FiltersInput.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/FiltersInput.tsx
@@ -155,7 +155,13 @@ const FiltersInput = (): JSX.Element => {
               borderRadius="full"
               variant="ghost"
               onClick={() => {
-                clearFilters(["userId", "roleId", "rolePlatformId", "action"])
+                clearFilters([
+                  "userId",
+                  "roleId",
+                  "rolePlatformId",
+                  "action",
+                  "guildId",
+                ])
                 setInputValue("")
               }}
             />

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/Suggestions.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/Suggestions.tsx
@@ -2,17 +2,21 @@ import { Stack, Text } from "@chakra-ui/react"
 import * as combobox from "@zag-js/combobox"
 import { HTMLAttributes, useMemo } from "react"
 import { ActivityLogType, useActivityLog } from "../../ActivityLogContext"
-import { Filter, SupportedQueryParam } from "./ActivityLogFiltersContext"
+import {
+  SupportedQueryParam,
+  useActivityLogFilters,
+} from "./ActivityLogFiltersContext"
 import Suggestion from "./Suggestion"
 
-interface Props {
+type Props = {
   contentProps: HTMLAttributes<HTMLElement>
   activityLogType: ActivityLogType
-  activeFilters: Filter[]
   getOptionProps: (props: combobox.OptionProps) => HTMLAttributes<HTMLElement>
 }
-const Suggestions = ({ contentProps, activeFilters, getOptionProps }) => {
+const Suggestions = ({ contentProps, getOptionProps }) => {
   const { activityLogType } = useActivityLog()
+  const { activeFilters } = useActivityLogFilters()
+
   const isActiveFilter = (filter: SupportedQueryParam) =>
     activeFilters?.some((af) => af.filter === filter)
 

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/Suggestions.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/Suggestions.tsx
@@ -1,0 +1,122 @@
+import { Stack, Text } from "@chakra-ui/react"
+import * as combobox from "@zag-js/combobox"
+import { HTMLAttributes, useMemo } from "react"
+import { ActivityLogType, useActivityLog } from "../../ActivityLogContext"
+import { Filter, SupportedQueryParam } from "./ActivityLogFiltersContext"
+import Suggestion from "./Suggestion"
+
+interface Props {
+  contentProps: HTMLAttributes<HTMLElement>
+  activityLogType: ActivityLogType
+  activeFilters: Filter[]
+  getOptionProps: (props: combobox.OptionProps) => HTMLAttributes<HTMLElement>
+}
+const Suggestions = ({ contentProps, activeFilters, getOptionProps }) => {
+  const { activityLogType } = useActivityLog()
+  const isActiveFilter = (filter: SupportedQueryParam) =>
+    activeFilters?.some((af) => af.filter === filter)
+
+  const shouldRenderSuggestions = useMemo((): {
+    guild: boolean
+    user: boolean
+    role: boolean
+    reward: boolean
+    action: boolean
+  } => {
+    switch (activityLogType) {
+      case "all":
+        return {
+          guild: !isActiveFilter("guildId"),
+          user: true,
+          role: !isActiveFilter("roleId") && isActiveFilter("guildId"),
+          reward: !isActiveFilter("rolePlatformId") && isActiveFilter("guildId"),
+          action: true,
+        }
+      case "user":
+        return {
+          guild: !isActiveFilter("guildId"),
+          user: false,
+          role: false,
+          reward: false,
+          action: true,
+        }
+      case "guild":
+        return {
+          guild: false,
+          user: true,
+          role: !isActiveFilter("roleId"),
+          reward: !isActiveFilter("rolePlatformId"),
+          action: true,
+        }
+      default:
+        return {
+          guild: false,
+          user: false,
+          role: false,
+          reward: false,
+          action: false,
+        }
+    }
+  }, [activityLogType, isActiveFilter])
+
+  return (
+    <Stack spacing={0} {...contentProps}>
+      {shouldRenderSuggestions.user && (
+        <Suggestion
+          label="User"
+          {...getOptionProps({ label: "User", value: "userId" })}
+        >
+          <Text as="span" colorScheme="gray" fontWeight="normal" noOfLines={1}>
+            Filter by wallet addresses
+          </Text>
+        </Suggestion>
+      )}
+
+      {shouldRenderSuggestions.guild && (
+        <Suggestion
+          label="Guild"
+          {...getOptionProps({ label: "Guild", value: "guildId" })}
+        >
+          <Text as="span" colorScheme="gray" fontWeight="normal" noOfLines={1}>
+            Filter by guild
+          </Text>
+        </Suggestion>
+      )}
+
+      {shouldRenderSuggestions.role && (
+        <Suggestion
+          label="Role"
+          {...getOptionProps({ label: "Role", value: "roleId" })}
+        >
+          <Text as="span" colorScheme="gray" fontWeight="normal" noOfLines={1}>
+            Filter by role
+          </Text>
+        </Suggestion>
+      )}
+
+      {shouldRenderSuggestions.reward && (
+        <Suggestion
+          label="Reward"
+          {...getOptionProps({ label: "Reward", value: "rolePlatformId" })}
+        >
+          <Text as="span" colorScheme="gray" fontWeight="normal" noOfLines={1}>
+            Filter by reward
+          </Text>
+        </Suggestion>
+      )}
+
+      {shouldRenderSuggestions.action && (
+        <Suggestion
+          label="Action"
+          {...getOptionProps({ label: "Action", value: "action" })}
+        >
+          <Text as="span" colorScheme="gray" fontWeight="normal" noOfLines={1}>
+            Filter by action
+          </Text>
+        </Suggestion>
+      )}
+    </Stack>
+  )
+}
+
+export default Suggestions

--- a/src/components/[guild]/activity/ActivityLogFiltersBar/components/Suggestions.tsx
+++ b/src/components/[guild]/activity/ActivityLogFiltersBar/components/Suggestions.tsx
@@ -1,7 +1,7 @@
 import { Stack, Text } from "@chakra-ui/react"
 import * as combobox from "@zag-js/combobox"
 import { HTMLAttributes, useMemo } from "react"
-import { ActivityLogType, useActivityLog } from "../../ActivityLogContext"
+import { useActivityLog } from "../../ActivityLogContext"
 import {
   SupportedQueryParam,
   useActivityLogFilters,
@@ -10,10 +10,10 @@ import Suggestion from "./Suggestion"
 
 type Props = {
   contentProps: HTMLAttributes<HTMLElement>
-  activityLogType: ActivityLogType
   getOptionProps: (props: combobox.OptionProps) => HTMLAttributes<HTMLElement>
 }
-const Suggestions = ({ contentProps, getOptionProps }) => {
+
+const Suggestions = ({ contentProps, getOptionProps }: Props) => {
   const { activityLogType } = useActivityLog()
   const { activeFilters } = useActivityLogFilters()
 

--- a/src/pages/superadmin/activity.tsx
+++ b/src/pages/superadmin/activity.tsx
@@ -14,11 +14,13 @@ import {
 import { ActivityLogFiltersProvider } from "components/[guild]/activity/ActivityLogFiltersBar/components/ActivityLogFiltersContext"
 import FiltersInput from "components/[guild]/activity/ActivityLogFiltersBar/components/FiltersInput"
 import ActivityLogSkeletons from "components/[guild]/activity/ActivityLogSkeleton"
+import useUser from "components/[guild]/hooks/useUser"
 import ErrorAlert from "components/common/ErrorAlert"
 import Layout from "components/common/Layout"
 import StickyBar from "components/common/Layout/StickyBar"
 import BackButton from "components/common/Layout/components/BackButton"
 import { SectionTitle } from "components/common/Section"
+import ErrorPage from "pages/_error"
 
 const ActivityLog = (): JSX.Element => {
   const bgColor = useColorModeValue("var(--chakra-colors-gray-800)", "#37373a") // dark color is from whiteAlpha.200, but without opacity so it can overlay the banner image
@@ -84,6 +86,10 @@ const ActivityLog = (): JSX.Element => {
 }
 
 const ActivityLogWrapper = (): JSX.Element => {
+  const { isSuperAdmin } = useUser()
+
+  if (!isSuperAdmin) return <ErrorPage statusCode={404} />
+
   return (
     <ThemeProvider>
       <ActivityLogProvider>

--- a/src/pages/superadmin/activity.tsx
+++ b/src/pages/superadmin/activity.tsx
@@ -86,9 +86,9 @@ const ActivityLog = (): JSX.Element => {
 }
 
 const ActivityLogWrapper = (): JSX.Element => {
-  const { isSuperAdmin } = useUser()
+  const { id, isSuperAdmin } = useUser()
 
-  if (!isSuperAdmin) return <ErrorPage statusCode={404} />
+  if (id && !isSuperAdmin) return <ErrorPage statusCode={404} />
 
   return (
     <ThemeProvider>

--- a/src/pages/superadmin/activity.tsx
+++ b/src/pages/superadmin/activity.tsx
@@ -1,0 +1,96 @@
+import {
+  Box,
+  Stack,
+  Text,
+  useBreakpointValue,
+  useColorModeValue,
+} from "@chakra-ui/react"
+import { ThemeProvider } from "components/[guild]/ThemeContext"
+import ActivityLogAction from "components/[guild]/activity/ActivityLogAction"
+import {
+  ActivityLogProvider,
+  useActivityLog,
+} from "components/[guild]/activity/ActivityLogContext"
+import { ActivityLogFiltersProvider } from "components/[guild]/activity/ActivityLogFiltersBar/components/ActivityLogFiltersContext"
+import FiltersInput from "components/[guild]/activity/ActivityLogFiltersBar/components/FiltersInput"
+import ActivityLogSkeletons from "components/[guild]/activity/ActivityLogSkeleton"
+import ErrorAlert from "components/common/ErrorAlert"
+import Layout from "components/common/Layout"
+import StickyBar from "components/common/Layout/StickyBar"
+import BackButton from "components/common/Layout/components/BackButton"
+import { SectionTitle } from "components/common/Section"
+
+const ActivityLog = (): JSX.Element => {
+  const bgColor = useColorModeValue("var(--chakra-colors-gray-800)", "#37373a") // dark color is from whiteAlpha.200, but without opacity so it can overlay the banner image
+  const bgOpacity = useColorModeValue(0.06, 0.1)
+  const bgLinearPercentage = useBreakpointValue({ base: "50%", sm: "55%" })
+
+  const { data, isValidating, isLoading, error } = useActivityLog()
+
+  return (
+    <Layout
+      title="Activity log"
+      background={bgColor}
+      backgroundProps={{
+        opacity: 1,
+        _before: {
+          content: '""',
+          position: "absolute",
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          bg: `linear-gradient(to top right, ${bgColor} ${bgLinearPercentage}, transparent), url('/banner.png ')`,
+          bgSize: { base: "auto 100%", sm: "auto 115%" },
+          bgRepeat: "no-repeat",
+          bgPosition: "top 10px right 0px",
+          opacity: bgOpacity,
+        },
+      }}
+      textColor="white"
+      backgroundOffset={46}
+      backButton={<BackButton />}
+    >
+      <ActivityLogFiltersProvider>
+        <StickyBar>
+          <FiltersInput />
+        </StickyBar>
+
+        <SectionTitle title="Actions" mt={8} mb="4" />
+        <Stack spacing={2.5}>
+          {isLoading ? (
+            <ActivityLogSkeletons />
+          ) : error ? (
+            <ErrorAlert
+              label={typeof error === "string" ? error : "Couldn't load actions"}
+              mb={0}
+            />
+          ) : data && !data?.entries?.length ? (
+            <Box p="8" borderWidth="2px" borderRadius={"2xl"} borderStyle={"dashed"}>
+              <Text colorScheme="gray">
+                No actions found for the filters you've set
+              </Text>
+            </Box>
+          ) : (
+            data?.entries?.map((action) => (
+              <ActivityLogAction key={action.id} action={action} />
+            ))
+          )}
+          {!isLoading && isValidating && <ActivityLogSkeletons />}
+        </Stack>
+      </ActivityLogFiltersProvider>
+    </Layout>
+  )
+}
+
+const ActivityLogWrapper = (): JSX.Element => {
+  return (
+    <ThemeProvider>
+      <ActivityLogProvider>
+        <ActivityLog />
+      </ActivityLogProvider>
+    </ThemeProvider>
+  )
+}
+
+export default ActivityLogWrapper


### PR DESCRIPTION
### Whats new
- new `superadmin/activity` url
- show 404 page if user is not superadmin
- in `ActivityLogContext`,  the `isUserActivity` prop is changed to `activityLogType` ("all",  "guild", and "user" activity logs)
- suggestions are rendered according to the `activityLogType`, moved to a separate `Suggestions` component
- fix for reward filter tags - after selecting a suggestion, they were not visible in the filter; now they are
---
### Todo
- [x] Test with a superadmin account
- [x] Clear all filters button is not working