### PR TITLE
fix: returning null instead of undefined

### DIFF
--- a/src/components/[guild]/RolePlatforms/components/EditRewardAvailabilityModal.tsx
+++ b/src/components/[guild]/RolePlatforms/components/EditRewardAvailabilityModal.tsx
@@ -53,12 +53,12 @@ const getShortDate = (isoDate: string): string | undefined => {
 }
 
 const datetimeLocalToIsoString = (datetimeLocal: string): string | undefined => {
-  if (!datetimeLocal) return undefined
+  if (!datetimeLocal) return null
 
   try {
     return new Date(datetimeLocal).toISOString()
   } catch {
-    return undefined
+    return null
   }
 }
 


### PR DESCRIPTION
In the "Edit Availability" modal for a reward, unchecking the "Limit claiming time" option and saving the changes does not remove the claiming time limit as expected. Instead, the time limit remains active.