### PR TITLE
chore(wallet activity): Remove Goerli, Mumbai, X1 testnet

### DIFF
--- a/src/requirements/WalletActivity/WalletActivityForm.tsx
+++ b/src/requirements/WalletActivity/WalletActivityForm.tsx
@@ -36,7 +36,6 @@ export const COVALENT_CHAINS = new Set<Chain>([
   "MANTLE",
   "RONIN",
   "ARBITRUM",
-  "X1_TESTNET",
   "METIS",
 ])
 
@@ -136,10 +135,7 @@ const WalletActivityForm = ({
     "LINEA",
     "MANTLE",
     "RONIN",
-    "X1_TESTNET",
     "METIS",
-    "GOERLI",
-    "POLYGON_MUMBAI",
   ]
 
   for (const covalentChain of COVALENT_CHAINS.values()) {


### PR DESCRIPTION
### General details

- Linear issue: [GUILD-2276](https://linear.app/guildxyz/issue/GUILD-2276/remove-unsupported-chains-from-wallet-activity)
- Discord thread: [bugs > Wallet activity - testnets?](https://discord.com/channels/697041998728659035/1201883761822670878)

### Core implementation details

Compared the supported chans list [on the frontend](https://github.com/guildxyz/guild.xyz/blob/main/src/requirements/WalletActivity/WalletActivityForm.tsx) and [in guild-gate](https://github.com/guildxyz/guild-gate/blob/main/src/requirements/covalent/types.ts). Removed unsupported entries from the frontend.