### PR TITLE
Rename Fuel token balance req to make it more clear

### DIFF
--- a/src/requirements/Fuel/FuelForm.tsx
+++ b/src/requirements/Fuel/FuelForm.tsx
@@ -10,7 +10,7 @@ import FuelTransactions from "./components/FuelTransactions"
 
 const fuelRequirementTypes = [
   {
-    label: "Token or NFT balance",
+    label: "Token balance",
     value: "FUEL_BALANCE",
     FuelRequirement: FuelBalance,
   },


### PR DESCRIPTION
Just a small text change to make the requirement more clear. It cannot check nfts at the moment.