### PR TITLE
fix: scroll restoration in guild explorer

### DIFF
--- a/src/components/common/Layout/components/NavMenu/NavMenu.tsx
+++ b/src/components/common/Layout/components/NavMenu/NavMenu.tsx
@@ -12,7 +12,10 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react"
 import Button from "components/common/Button"
+import { useSetAtom } from "jotai"
 import dynamic from "next/dynamic"
+import { useRouter } from "next/router"
+import { ExplorerScrollRestoration } from "pages/explorer"
 import {
   CircleWavyCheck,
   Code,
@@ -37,6 +40,8 @@ const AnimatedLogo = dynamic(() => import("components/explorer/AnimatedLogo"), {
 
 const NavMenu = (): JSX.Element => {
   const darkBgColor = useColorModeValue("gray.50", "blackAlpha.300")
+  const setExplorerScrollRestoration = useSetAtom(ExplorerScrollRestoration)
+  const router = useRouter()
 
   return (
     <Popover placement="bottom-start">
@@ -70,7 +75,15 @@ const NavMenu = (): JSX.Element => {
             gap={{ base: 2, sm: 12 }}
           >
             <NavGroup title="Navigation">
-              <NavButton leftIcon={<House />} href="/explorer">
+              <NavButton
+                leftIcon={<House />}
+                href="/explorer"
+                onClick={(e) => {
+                  e.preventDefault()
+                  setExplorerScrollRestoration(false)
+                  router.push("/explorer")
+                }}
+              >
                 Explore all guilds
               </NavButton>
               <NavButton leftIcon={<Plus />} href="/create-guild">

--- a/src/components/common/Layout/components/NavMenu/NavMenu.tsx
+++ b/src/components/common/Layout/components/NavMenu/NavMenu.tsx
@@ -15,7 +15,7 @@ import Button from "components/common/Button"
 import { useSetAtom } from "jotai"
 import dynamic from "next/dynamic"
 import { useRouter } from "next/router"
-import { ExplorerScrollRestoration } from "pages/explorer"
+import { explorerScrollRestorationAtom } from "pages/explorer"
 import {
   CircleWavyCheck,
   Code,
@@ -40,7 +40,7 @@ const AnimatedLogo = dynamic(() => import("components/explorer/AnimatedLogo"), {
 
 const NavMenu = (): JSX.Element => {
   const darkBgColor = useColorModeValue("gray.50", "blackAlpha.300")
-  const setExplorerScrollRestoration = useSetAtom(ExplorerScrollRestoration)
+  const setExplorerScrollRestoration = useSetAtom(explorerScrollRestorationAtom)
   const router = useRouter()
 
   return (

--- a/src/components/explorer/hooks/useRestoreScroll.ts
+++ b/src/components/explorer/hooks/useRestoreScroll.ts
@@ -1,0 +1,58 @@
+import { useRouter } from "next/router"
+import { useEffect } from "react"
+
+const scrollPositions = new Map()
+
+/**
+ * Used for scroll restoration when navigating to the page. FOR ALL NAVIGATIONS, NOT
+ * ONLY FOR BACKWARDS NAVIGATION!
+ *
+ * @param param0
+ */
+const useRestoreScroll = ({
+  active = true,
+  onRestore,
+}: {
+  active?: boolean
+  onRestore?: () => void
+}) => {
+  const router = useRouter()
+
+  useEffect(() => {
+    const handleRouteChangeStart = (url: string) => {
+      if (router.asPath === url) return
+      scrollPositions.set(router.asPath, window.scrollY)
+    }
+
+    const handleRouteChangeComplete = () => {
+      const savedPosition = scrollPositions.get(router.asPath) || 0
+
+      if (!active) {
+        if (!!onRestore) onRestore()
+        return
+      }
+      /**
+       * For some reason, without the delay, the scrolling is not executed. It
+       * might be caused by the default 'scrollRestoration', which probably
+       * overwrites our own scrolling, if not delayed.
+       */
+      setTimeout(() => {
+        window.scrollTo({
+          top: savedPosition,
+          left: 0,
+        })
+      }, 10)
+      if (!!onRestore) onRestore()
+    }
+
+    router.events.on("routeChangeStart", handleRouteChangeStart)
+    router.events.on("routeChangeComplete", handleRouteChangeComplete)
+
+    return () => {
+      router.events.off("routeChangeStart", handleRouteChangeStart)
+      router.events.off("routeChangeComplete", handleRouteChangeComplete)
+    }
+  }, [router, scrollPositions, active, onRestore])
+}
+
+export default useRestoreScroll

--- a/src/components/explorer/hooks/useScrollRestoration.ts
+++ b/src/components/explorer/hooks/useScrollRestoration.ts
@@ -9,7 +9,7 @@ const scrollPositions = new Map()
  *
  * @param param0
  */
-const useRestoreScroll = ({
+const useScrollRestoration = ({
   active = true,
   onRestore,
 }: {
@@ -32,9 +32,9 @@ const useRestoreScroll = ({
         return
       }
       /**
-       * For some reason, without the delay, the scrolling is not executed. It
-       * might be caused by the default 'scrollRestoration', which probably
-       * overwrites our own scrolling, if not delayed.
+       * For some reason, without the delay, the scrolling is not executed. It might
+       * be caused by the default 'scrollRestoration', which probably overwrites our
+       * own scrolling, if not delayed.
        */
       setTimeout(() => {
         window.scrollTo({
@@ -55,4 +55,4 @@ const useRestoreScroll = ({
   }, [router, scrollPositions, active, onRestore])
 }
 
-export default useRestoreScroll
+export default useScrollRestoration

--- a/src/pages/explorer.tsx
+++ b/src/pages/explorer.tsx
@@ -6,7 +6,7 @@ import ExploreAllGuilds from "components/explorer/ExploreAllGuilds"
 import ExplorerTabs from "components/explorer/ExplorerTabs"
 import GoToCreateGuildButton from "components/explorer/GoToCreateGuildButton"
 import YourGuilds, { useYourGuilds } from "components/explorer/YourGuilds"
-import useRestoreScroll from "components/explorer/hooks/useRestoreScroll"
+import useScrollRestoration from "components/explorer/hooks/useScrollRestoration"
 import { atom, useAtom } from "jotai"
 import { GetStaticProps } from "next"
 import { useRef } from "react"
@@ -32,7 +32,7 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
     explorerScrollRestorationAtom
   )
 
-  useRestoreScroll({
+  useScrollRestoration({
     active: shouldRestoreScroll,
     onRestore: () => setShouldRestoreScroll(true),
   })

--- a/src/pages/explorer.tsx
+++ b/src/pages/explorer.tsx
@@ -32,7 +32,7 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
     explorerScrollRestorationAtom
   )
 
-  const scrollRestoration = useRestoreScroll({
+  useRestoreScroll({
     active: shouldRestoreScroll,
     onRestore: () => setShouldRestoreScroll(true),
   })

--- a/src/pages/explorer.tsx
+++ b/src/pages/explorer.tsx
@@ -6,7 +6,6 @@ import ExploreAllGuilds from "components/explorer/ExploreAllGuilds"
 import ExplorerTabs from "components/explorer/ExplorerTabs"
 import GoToCreateGuildButton from "components/explorer/GoToCreateGuildButton"
 import YourGuilds, { useYourGuilds } from "components/explorer/YourGuilds"
-import { atom, useAtom } from "jotai"
 import { GetStaticProps } from "next"
 import { useRouter } from "next/router"
 import { useEffect, useRef } from "react"
@@ -17,7 +16,7 @@ type Props = {
   guilds: GuildBase[]
 }
 
-const ExplorerScrollPositionAtom = atom(0)
+let scrollPosition = 0
 
 const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
   const yourGuildsRef = useRef(null)
@@ -30,13 +29,10 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
   const bgLinearPercentage = useBreakpointValue({ base: "50%", sm: "55%" })
 
   const router = useRouter()
-  const [explorerScrollPosition, setExplorerScrollPositionAtom] = useAtom(
-    ExplorerScrollPositionAtom
-  )
 
   useEffect(() => {
     const handleRouteChangeStart = () => {
-      setExplorerScrollPositionAtom(window.scrollY)
+      scrollPosition = window.scrollY
     }
 
     const handleRouteChangeComplete = () => {
@@ -48,7 +44,7 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
       setTimeout(
         () =>
           window.scrollTo({
-            top: explorerScrollPosition,
+            top: scrollPosition,
             left: 0,
             behavior: "smooth",
           }),
@@ -63,7 +59,7 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
       router.events.off("routeChangeStart", handleRouteChangeStart)
       router.events.off("routeChangeComplete", handleRouteChangeComplete)
     }
-  }, [router, explorerScrollPosition])
+  }, [router, scrollPosition])
 
   return (
     <>

--- a/src/pages/explorer.tsx
+++ b/src/pages/explorer.tsx
@@ -17,7 +17,7 @@ type Props = {
   guilds: GuildBase[]
 }
 
-export const ExplorerScrollRestoration = atom(true)
+export const explorerScrollRestorationAtom = atom(true)
 
 const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
   const yourGuildsRef = useRef(null)
@@ -29,7 +29,7 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
   const bgOpacity = useColorModeValue(0.06, 0.1)
   const bgLinearPercentage = useBreakpointValue({ base: "50%", sm: "55%" })
   const [shouldRestoreScroll, setShouldRestoreScroll] = useAtom(
-    ExplorerScrollRestoration
+    explorerScrollRestorationAtom
   )
 
   const scrollRestoration = useRestoreScroll({

--- a/src/pages/explorer.tsx
+++ b/src/pages/explorer.tsx
@@ -6,14 +6,18 @@ import ExploreAllGuilds from "components/explorer/ExploreAllGuilds"
 import ExplorerTabs from "components/explorer/ExplorerTabs"
 import GoToCreateGuildButton from "components/explorer/GoToCreateGuildButton"
 import YourGuilds, { useYourGuilds } from "components/explorer/YourGuilds"
+import { atom, useAtom } from "jotai"
 import { GetStaticProps } from "next"
-import { useRef } from "react"
+import { useRouter } from "next/router"
+import { useEffect, useRef } from "react"
 import { GuildBase } from "types"
 import fetcher from "utils/fetcher"
 
 type Props = {
   guilds: GuildBase[]
 }
+
+const ExplorerScrollPositionAtom = atom(0)
 
 const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
   const yourGuildsRef = useRef(null)
@@ -24,6 +28,42 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
   const bgColor = useColorModeValue("var(--chakra-colors-gray-800)", "#37373a") // dark color is from whiteAlpha.200, but without opacity so it can overlay the banner image
   const bgOpacity = useColorModeValue(0.06, 0.1)
   const bgLinearPercentage = useBreakpointValue({ base: "50%", sm: "55%" })
+
+  const router = useRouter()
+  const [explorerScrollPosition, setExplorerScrollPositionAtom] = useAtom(
+    ExplorerScrollPositionAtom
+  )
+
+  useEffect(() => {
+    const handleRouteChangeStart = () => {
+      setExplorerScrollPositionAtom(window.scrollY)
+    }
+
+    const handleRouteChangeComplete = () => {
+      /**
+       * For some reason, without the delay, the scrolling is not executed. It might
+       * be caused by the default 'scrollRestoration', which probably overwrites our
+       * own scrolling, if not delayed.
+       */
+      setTimeout(
+        () =>
+          window.scrollTo({
+            top: explorerScrollPosition,
+            left: 0,
+            behavior: "smooth",
+          }),
+        10
+      )
+    }
+
+    router.events.on("routeChangeStart", handleRouteChangeStart)
+    router.events.on("routeChangeComplete", handleRouteChangeComplete)
+
+    return () => {
+      router.events.off("routeChangeStart", handleRouteChangeStart)
+      router.events.off("routeChangeComplete", handleRouteChangeComplete)
+    }
+  }, [router, explorerScrollPosition])
 
   return (
     <>

--- a/src/pages/explorer.tsx
+++ b/src/pages/explorer.tsx
@@ -6,6 +6,7 @@ import ExploreAllGuilds from "components/explorer/ExploreAllGuilds"
 import ExplorerTabs from "components/explorer/ExplorerTabs"
 import GoToCreateGuildButton from "components/explorer/GoToCreateGuildButton"
 import YourGuilds, { useYourGuilds } from "components/explorer/YourGuilds"
+import { atom, useAtom } from "jotai"
 import { GetStaticProps } from "next"
 import { useRouter } from "next/router"
 import { useEffect, useRef } from "react"
@@ -16,6 +17,7 @@ type Props = {
   guilds: GuildBase[]
 }
 
+export const ExplorerScrollRestoration = atom(true)
 let scrollPosition = 0
 
 const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
@@ -29,6 +31,9 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
   const bgLinearPercentage = useBreakpointValue({ base: "50%", sm: "55%" })
 
   const router = useRouter()
+  const [shouldRestoreScroll, setShouldRestoreScroll] = useAtom(
+    ExplorerScrollRestoration
+  )
 
   useEffect(() => {
     const handleRouteChangeStart = () => {
@@ -36,6 +41,10 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
     }
 
     const handleRouteChangeComplete = () => {
+      if (!shouldRestoreScroll) {
+        setShouldRestoreScroll(true)
+        return
+      }
       /**
        * For some reason, without the delay, the scrolling is not executed. It might
        * be caused by the default 'scrollRestoration', which probably overwrites our
@@ -59,7 +68,7 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
       router.events.off("routeChangeStart", handleRouteChangeStart)
       router.events.off("routeChangeComplete", handleRouteChangeComplete)
     }
-  }, [router, scrollPosition])
+  }, [router, scrollPosition, shouldRestoreScroll])
 
   return (
     <>

--- a/src/pages/explorer.tsx
+++ b/src/pages/explorer.tsx
@@ -55,7 +55,6 @@ const Page = ({ guilds: guildsInitial }: Props): JSX.Element => {
           window.scrollTo({
             top: scrollPosition,
             left: 0,
-            behavior: "smooth",
           }),
         10
       )


### PR DESCRIPTION
I implemented a custom scroll restoration for the explorer page.

The built-in scroll restoration functioned only with backward navigation, such as using `router.back()` or the browser's back button. However, our "Back to explorer" link doesn't operate in this manner; it directs us to the `/explorer` URL instead of navigating back.

Additionally, the standard scroll restoration is affected by the "Your guilds" list, as it loads after the scroll position has been restored, altering the expected position.

Note that I had to implement an undesirable delay in the manual scroll restoration. This is because the built-in restoration and our custom solution currently execute simultaneously. Without this delay, the built-in mechanism would override our manual approach.

If the built-in scroll restoration is not essential elsewhere, I recommend disabling it. This change would allow us to eliminate the delay