### PR TITLE
fix(access check): check for falsy value instead of `null`

### DIFF
--- a/src/components/[guild]/Requirements/components/HiddenRequirementAccessIndicator.tsx
+++ b/src/components/[guild]/Requirements/components/HiddenRequirementAccessIndicator.tsx
@@ -59,7 +59,7 @@ const HiddenRequirementAccessIndicator = ({ roleId }: Props) => {
       reqAccesses
         ?.filter(
           (req) =>
-            !!req.access === null &&
+            !req.access &&
             !publicReqIds.includes(req.requirementId) &&
             !["PLATFORM_NOT_CONNECTED", "PLATFORM_CONNECT_INVALID"].includes(
               req.errorType
@@ -77,7 +77,8 @@ const HiddenRequirementAccessIndicator = ({ roleId }: Props) => {
       }
 
       const reqError = reqAccesses?.find(
-        (obj) => obj.requirementId === curr.requirementId && obj.access === null
+        (obj) =>
+          obj.requirementId === curr.requirementId && !obj.access && !!obj.errorMsg
       )
       if (!reqError) {
         acc.notAccessed += 1

--- a/src/components/[guild]/RoleCard/components/AccessIndicator/AccessIndicator.tsx
+++ b/src/components/[guild]/RoleCard/components/AccessIndicator/AccessIndicator.tsx
@@ -41,15 +41,15 @@ const AccessIndicator = ({ roleId, isOpen, onToggle }: Props): JSX.Element => {
   const greenDividerColor = useColorModeValue("green.400", "whiteAlpha.400")
   const grayDividerColor = useColorModeValue("blackAlpha.400", "whiteAlpha.300")
 
-  const requirementsWithErrors = role?.requirements?.filter(
-    (req) => reqAccesses?.find((r) => r.requirementId === req.id)?.access === null
+  const requirementsWithNoAccess = role?.requirements?.filter(
+    (req) => !reqAccesses?.find((r) => r.requirementId === req.id)?.access
   )
   const errors = useRequirementErrorConfig()
-  const firstRequirementWithErrorFromConfig = requirementsWithErrors.find(
+  const firstRequirementWithErrorFromConfig = requirementsWithNoAccess.find(
     (req) => !!errors[req.type.split("_")[0]]
   )
   const errorTextFromConfig =
-    requirementsWithErrors.length > 0 &&
+    requirementsWithNoAccess.length > 0 &&
     errors[firstRequirementWithErrorFromConfig?.type.split("_")[0]]
 
   if (!isMember)
@@ -141,7 +141,7 @@ const AccessIndicator = ({ roleId, isOpen, onToggle }: Props): JSX.Element => {
       />
     )
 
-  if (requirementsWithErrors?.length > 0 || error)
+  if (requirementsWithNoAccess?.length > 0 || error)
     return (
       <HStack spacing="0" flexShrink={0}>
         <AccessIndicatorUI


### PR DESCRIPTION
Gate will return `access:false` with `PLATFORM_CONNECT_INVALID` & `PLATFORM_NOT_CONNECTED` errors from now, so we should check for falsy values (instead of `null`) where we use requirement access in if statements / filters / etc.