### PR TITLE
[GUILD-2561] - Email allowlist

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.0",
         "@fuel-wallet/react": "^0.16.0",
-        "@guildxyz/types": "1.7.11",
+        "@guildxyz/types": "1.7.31",
         "@hcaptcha/react-hcaptcha": "^1.4.4",
         "@hookform/resolvers": "^3.3.4",
         "@lexical/code": "^0.12.0",
@@ -4964,9 +4964,9 @@
       }
     },
     "node_modules/@guildxyz/types": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@guildxyz/types/-/types-1.7.11.tgz",
-      "integrity": "sha512-chxQesWEUoU7I4jzBnhRgBD2gDZByh9/xdq5ElszHD4HWmoEoqObWp77smr8c3DPdACN32HHOTwPyePSJWSNyw==",
+      "version": "1.7.31",
+      "resolved": "https://registry.npmjs.org/@guildxyz/types/-/types-1.7.31.tgz",
+      "integrity": "sha512-SMtqlkgtpRiTQHBGtAW6IjffvGDC74hqwUdt5h4jPd/3gR3QHlC+YY1Gq3V2ThFkMbJ+gZfIMusWeyzUadYkUw==",
       "dependencies": {
         "zod": "^3.22.4"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
     "@fuel-wallet/react": "^0.16.0",
-    "@guildxyz/types": "1.7.11",
+    "@guildxyz/types": "1.7.31",
     "@hcaptcha/react-hcaptcha": "^1.4.4",
     "@hookform/resolvers": "^3.3.4",
     "@lexical/code": "^0.12.0",

--- a/src/components/[guild]/Requirements/components/RequirementAccessIndicator.tsx
+++ b/src/components/[guild]/Requirements/components/RequirementAccessIndicator.tsx
@@ -29,6 +29,12 @@ const DynamicConnectRequirementPlatformButton = dynamic(
   () => import("./ConnectRequirementPlatformButton")
 )
 
+const NON_CONNECTABLE_PLATFORM_ERRORS = new Set([
+  "EVM address not connected",
+  "FUEL address not connected",
+  "Email address not found, please create one.",
+])
+
 const RequirementAccessIndicator = () => {
   const setIsAccountModalOpen = useSetAtom(accountModalAtom)
   const { id, roleId, type, data, isNegated } = useRequirementContext()
@@ -57,8 +63,7 @@ const RequirementAccessIndicator = () => {
   if (
     (reqAccessData?.errorType === "PLATFORM_NOT_CONNECTED" ||
       reqAccessData?.errorType === "PLATFORM_CONNECT_INVALID") &&
-    reqAccessData?.errorMsg !== "EVM address not connected" &&
-    reqAccessData?.errorMsg !== "FUEL address not connected"
+    !NON_CONNECTABLE_PLATFORM_ERRORS.has(reqAccessData?.errorMsg ?? "")
   )
     return (
       <RequirementAccessIndicatorUI

--- a/src/requirements/Allowlist/AllowlistForm.tsx
+++ b/src/requirements/Allowlist/AllowlistForm.tsx
@@ -82,9 +82,7 @@ const AllowlistForm = ({
         ?.toString()
         ?.split("\n")
         ?.filter((line) => !!line)
-        ?.map((line) =>
-          type === "ALLOWLIST_EMAIL" ? line.trim() : line.slice(0, 42)
-        )
+        ?.map((line) => line.trim())
 
       setValue(`${baseFieldPath}.data.addresses`, lines, { shouldValidate: true })
     }

--- a/src/requirements/Allowlist/AllowlistForm.tsx
+++ b/src/requirements/Allowlist/AllowlistForm.tsx
@@ -8,24 +8,61 @@ import {
 } from "@chakra-ui/react"
 import { isValidAddress } from "components/[guild]/EditGuild/components/Admins/Admins"
 import Button from "components/common/Button"
+import ControlledSelect from "components/common/ControlledSelect"
 import FormErrorMessage from "components/common/FormErrorMessage"
+import { StyledSelectProps } from "components/common/StyledSelect/StyledSelect"
 import useDropzone from "hooks/useDropzone"
 import { useRouter } from "next/router"
 import { File } from "phosphor-react"
 import { Controller, useFormContext, useWatch } from "react-hook-form"
 import { RequirementFormProps } from "requirements"
 import parseFromObject from "utils/parseFromObject"
+import { z } from "zod"
 
-const AllowlistForm = ({ baseFieldPath }: RequirementFormProps): JSX.Element => {
+function validateEmailAllowlist(toValidate: string[]) {
+  if (!toValidate) return
+
+  const containsEmpty = toValidate.some((address) => address === "")
+
+  if (containsEmpty) {
+    return "Field contains empty line"
+  }
+
+  const invalidEmails = toValidate.filter(
+    (address) => !z.string().email().safeParse(address).success
+  )
+
+  if (invalidEmails.length > 0) {
+    return `Field contains invalid email address: ${invalidEmails[0]}`
+  }
+}
+
+const allowListTypeOptions = [
+  {
+    label: "EVM and Fuel addresses",
+    value: "ALLOWLIST",
+  },
+  {
+    label: "Email addresses",
+    value: "ALLOWLIST_EMAIL",
+  },
+] satisfies StyledSelectProps["options"]
+
+const AllowlistForm = ({
+  baseFieldPath,
+  field,
+}: RequirementFormProps): JSX.Element => {
   const {
     setValue,
     formState: { errors },
     control,
     register,
+    resetField,
   } = useFormContext()
   const router = useRouter()
 
   const isHidden = useWatch({ name: `${baseFieldPath}.data.hideAllowlist` })
+  const isEditMode = !!field?.id
 
   const { isDragActive, fileRejections, getRootProps, getInputProps } = useDropzone({
     multiple: false,
@@ -35,6 +72,8 @@ const AllowlistForm = ({ baseFieldPath }: RequirementFormProps): JSX.Element => 
     },
   })
 
+  const type = useWatch({ name: `${baseFieldPath}.type` })
+
   const parseFile = (file: File) => {
     const fileReader = new FileReader()
 
@@ -43,7 +82,9 @@ const AllowlistForm = ({ baseFieldPath }: RequirementFormProps): JSX.Element => 
         ?.toString()
         ?.split("\n")
         ?.filter((line) => !!line)
-        ?.map((line) => line.slice(0, 42))
+        ?.map((line) =>
+          type === "ALLOWLIST_EMAIL" ? line.trim() : line.slice(0, 42)
+        )
 
       setValue(`${baseFieldPath}.data.addresses`, lines, { shouldValidate: true })
     }
@@ -51,8 +92,30 @@ const AllowlistForm = ({ baseFieldPath }: RequirementFormProps): JSX.Element => 
     fileReader.readAsText(file)
   }
 
+  const resetFields = () => {
+    resetField(`${baseFieldPath}.data.addresses`, { defaultValue: [] })
+  }
+
   return (
     <Stack spacing={4} alignItems="start" {...getRootProps()}>
+      <FormControl
+        isInvalid={!!parseFromObject(errors, baseFieldPath)?.type?.message}
+      >
+        <FormLabel>Type</FormLabel>
+
+        <ControlledSelect
+          name={`${baseFieldPath}.type`}
+          defaultValue={"ALLOWLIST"}
+          options={allowListTypeOptions}
+          beforeOnChange={resetFields}
+          isDisabled={isEditMode}
+        />
+
+        <FormErrorMessage>
+          {parseFromObject(errors, baseFieldPath)?.type?.message}
+        </FormErrorMessage>
+      </FormControl>
+
       <FormControl isInvalid={!!fileRejections?.[0]} textAlign="left">
         <FormLabel>Upload from file</FormLabel>
 
@@ -75,21 +138,24 @@ const AllowlistForm = ({ baseFieldPath }: RequirementFormProps): JSX.Element => 
           control={control}
           name={`${baseFieldPath}.data.addresses` as const}
           rules={{
-            validate: (value_) => {
-              if (!value_) return
+            validate:
+              type === "ALLOWLIST_EMAIL"
+                ? validateEmailAllowlist
+                : (value_) => {
+                    if (!value_) return
 
-              const validAddresses = value_.filter(
-                (address) => address !== "" && isValidAddress(address)
-              )
-              // for useBalancy
-              setValue(`${baseFieldPath}.data.validAddresses`, validAddresses)
+                    const validAddresses = value_.filter(
+                      (address) => address !== "" && isValidAddress(address)
+                    )
+                    // for useBalancy
+                    setValue(`${baseFieldPath}.data.validAddresses`, validAddresses)
 
-              if (validAddresses.length !== value_.length)
-                return "Field contains invalid addresses"
+                    if (validAddresses.length !== value_.length)
+                      return "Field contains invalid addresses"
 
-              if (router.route !== "/balancy" && value_.length > 50000)
-                return `You've added ${value_.length} addresses but the maximum is 50000`
-            },
+                    if (router.route !== "/balancy" && value_.length > 50000)
+                      return `You've added ${value_.length} addresses but the maximum is 50000`
+                  },
           }}
           render={({ field: { onChange, onBlur, value: textareaValue, ref } }) => (
             <Textarea

--- a/src/requirements/Allowlist/AllowlistRequirement.tsx
+++ b/src/requirements/Allowlist/AllowlistRequirement.tsx
@@ -44,7 +44,7 @@ const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
         isOpen={isOpen}
         onClose={onClose}
         title={
-          requirement.type === "ALLOWLIST_EMAIL" ? "Email alllowlist" : "Allowlist"
+          requirement.type === "ALLOWLIST_EMAIL" ? "Email allowlist" : "Allowlist"
         }
       />
     </Requirement>

--- a/src/requirements/Allowlist/AllowlistRequirement.tsx
+++ b/src/requirements/Allowlist/AllowlistRequirement.tsx
@@ -1,4 +1,5 @@
 import { Icon, Text, useDisclosure } from "@chakra-ui/react"
+import { Schemas } from "@guildxyz/types"
 import Requirement, {
   RequirementProps,
 } from "components/[guild]/Requirements/components/Requirement"
@@ -8,7 +9,10 @@ import { ArrowSquareIn, ListPlus } from "phosphor-react"
 import SearchableVirtualListModal from "requirements/common/SearchableVirtualListModal"
 
 const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
-  const requirement = useRequirementContext()
+  const requirement = useRequirementContext() as Extract<
+    Schemas["Requirement"],
+    { type: "ALLOWLIST" | "ALLOWLIST_EMAIL" }
+  >
 
   const { addresses, hideAllowlist } = requirement.data
 
@@ -20,7 +24,8 @@ const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
       footer={
         hideAllowlist && (
           <Text color="gray" fontSize="xs" fontWeight="normal">
-            Allowlisted addresses are hidden
+            Allowlisted{requirement.type === "ALLOWLIST_EMAIL" ? " email" : ""}{" "}
+            addresses are hidden
           </Text>
         )
       }
@@ -28,17 +33,19 @@ const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
     >
       {"Be included in "}
       {hideAllowlist ? (
-        "allowlist"
+        `${requirement.type === "ALLOWLIST_EMAIL" ? "email " : ""}allowlist`
       ) : (
         <Button variant="link" rightIcon={<ArrowSquareIn />} onClick={onOpen}>
-          allowlist
+          {requirement.type === "ALLOWLIST_EMAIL" ? "email " : ""}allowlist
         </Button>
       )}
       <SearchableVirtualListModal
         initialList={addresses}
         isOpen={isOpen}
         onClose={onClose}
-        title="Allowlist"
+        title={
+          requirement.type === "ALLOWLIST_EMAIL" ? "Email alllowlist" : "Allowlist"
+        }
       />
     </Requirement>
   )

--- a/src/requirements/Allowlist/AllowlistRequirement.tsx
+++ b/src/requirements/Allowlist/AllowlistRequirement.tsx
@@ -18,14 +18,15 @@ const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
 
   const { isOpen, onOpen, onClose } = useDisclosure()
 
+  const isEmail = requirement.type === "ALLOWLIST_EMAIL"
+
   return (
     <Requirement
       image={<Icon as={ListPlus} boxSize={6} />}
       footer={
         hideAllowlist && (
           <Text color="gray" fontSize="xs" fontWeight="normal">
-            Allowlisted{requirement.type === "ALLOWLIST_EMAIL" ? " email" : ""}{" "}
-            addresses are hidden
+            {`Allowlisted ${isEmail ? " email" : ""} addresses are hidden`}
           </Text>
         )
       }
@@ -33,19 +34,17 @@ const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
     >
       {"Be included in "}
       {hideAllowlist ? (
-        `${requirement.type === "ALLOWLIST_EMAIL" ? "email " : ""}allowlist`
+        `${isEmail ? "email " : ""}allowlist`
       ) : (
         <Button variant="link" rightIcon={<ArrowSquareIn />} onClick={onOpen}>
-          {requirement.type === "ALLOWLIST_EMAIL" ? "email " : ""}allowlist
+          {`${isEmail ? "email " : ""}allowlist`}
         </Button>
       )}
       <SearchableVirtualListModal
         initialList={addresses}
         isOpen={isOpen}
         onClose={onClose}
-        title={
-          requirement.type === "ALLOWLIST_EMAIL" ? "Email allowlist" : "Allowlist"
-        }
+        title={isEmail ? "Email allowlist" : "Allowlist"}
       />
     </Requirement>
   )

--- a/src/requirements/requirements.ts
+++ b/src/requirements/requirements.ts
@@ -58,7 +58,7 @@ export const REQUIREMENTS_DATA = [
     formComponent: dynamic<RequirementFormProps>(
       () => import("requirements/Allowlist/AllowlistForm")
     ),
-    types: ["ALLOWLIST"],
+    types: ["ALLOWLIST", "ALLOWLIST_EMAIL"],
     isNegatable: true,
   },
   {


### PR DESCRIPTION
- `RequirementAccessIndicator`: Turned out that a missing email is also returned as a platform error, so I added a condition for that as well. Started to get ugly, so added a const for the messages
- Added a `type` selector for the allowlist form with options `EVM and Fuel addresses` and `Email addresses`
- Validation uses `z.string().email()` just to be sure that it validates using the same email rules, as the schema used on BE
- Companion PRs:
  - Gate: https://github.com/guildxyz/guild-gate/pull/715
  - Core: https://github.com/guildxyz/guild-backend/pull/1369