### PR TITLE
[GUILD-2599] - Email allowlist improvements

### DIFF
--- a/src/components/[guild]/Requirements/components/ConnectRequirementPlatformButton.tsx
+++ b/src/components/[guild]/Requirements/components/ConnectRequirementPlatformButton.tsx
@@ -7,17 +7,20 @@ import { ConnectEmailButton } from "components/common/Layout/components/Account/
 import { useRoleMembership } from "components/explorer/hooks/useMembership"
 import useToast from "hooks/useToast"
 import rewards from "platforms/rewards"
-import REQUIREMENTS from "requirements"
+import REQUIREMENTS, { RequirementType } from "requirements"
 import { PlatformName } from "types"
 import { useRequirementContext } from "./RequirementContext"
+
+function requirementTypeToPlatformName(type: RequirementType): PlatformName {
+  if (type === "ALLOWLIST_EMAIL") return "EMAIL"
+  if (REQUIREMENTS[type].types[0] === "TWITTER") return "TWITTER_V1"
+  return REQUIREMENTS[type].types[0] as PlatformName
+}
 
 const RequirementConnectButton = (props: ButtonProps) => {
   const { platformUsers, emails } = useUser()
   const { type, roleId, id } = useRequirementContext()
-  const platform =
-    REQUIREMENTS[type].types[0] === "TWITTER"
-      ? "TWITTER_V1"
-      : (REQUIREMENTS[type].types[0] as PlatformName)
+  const platform = requirementTypeToPlatformName(type)
 
   const { reqAccesses } = useRoleMembership(roleId)
   const { triggerMembershipUpdate } = useMembershipUpdate()
@@ -33,7 +36,7 @@ const RequirementConnectButton = (props: ButtonProps) => {
   )
 
   if (
-    type?.startsWith("EMAIL")
+    platform === "EMAIL"
       ? !emails?.pending && emails?.emailAddress
       : !isReconnection && (!platformUsers || platformFromDb)
   )
@@ -48,9 +51,8 @@ const RequirementConnectButton = (props: ButtonProps) => {
     })
   }
 
-  const ButtonComponent = type?.startsWith("EMAIL")
-    ? ConnectEmailButton
-    : ConnectRequirementPlatformButton
+  const ButtonComponent =
+    platform === "EMAIL" ? ConnectEmailButton : ConnectRequirementPlatformButton
 
   return (
     <ButtonComponent

--- a/src/platforms/rewards.tsx
+++ b/src/platforms/rewards.tsx
@@ -113,7 +113,7 @@ const rewards: Record<PlatformName, RewardData> = {
   EMAIL: {
     icon: EnvelopeSimple,
     name: "Email",
-    colorScheme: "gray",
+    colorScheme: "blue",
     gatedEntity: "email",
     isPlatform: true,
     asRewardRestriction: PlatformAsRewardRestrictions.NOT_APPLICABLE,

--- a/src/requirements/Allowlist/AllowlistForm.tsx
+++ b/src/requirements/Allowlist/AllowlistForm.tsx
@@ -1,41 +1,11 @@
-import {
-  Checkbox,
-  FormControl,
-  FormLabel,
-  Stack,
-  Text,
-  Textarea,
-} from "@chakra-ui/react"
-import { isValidAddress } from "components/[guild]/EditGuild/components/Admins/Admins"
-import Button from "components/common/Button"
+import { FormControl, FormLabel, Stack } from "@chakra-ui/react"
 import ControlledSelect from "components/common/ControlledSelect"
 import FormErrorMessage from "components/common/FormErrorMessage"
 import { StyledSelectProps } from "components/common/StyledSelect/StyledSelect"
-import useDropzone from "hooks/useDropzone"
-import { useRouter } from "next/router"
-import { File } from "phosphor-react"
-import { Controller, useFormContext, useWatch } from "react-hook-form"
+import { useFormContext } from "react-hook-form"
 import { RequirementFormProps } from "requirements"
 import parseFromObject from "utils/parseFromObject"
-import { z } from "zod"
-
-function validateEmailAllowlist(toValidate: string[]) {
-  if (!toValidate) return
-
-  const containsEmpty = toValidate.some((address) => address === "")
-
-  if (containsEmpty) {
-    return "Field contains empty line"
-  }
-
-  const invalidEmails = toValidate.filter(
-    (address) => !z.string().email().safeParse(address).success
-  )
-
-  if (invalidEmails.length > 0) {
-    return `Field contains invalid email address: ${invalidEmails[0]}`
-  }
-}
+import AllowlistFormInputs from "./components/AllowlistFormInputs"
 
 const allowListTypeOptions = [
   {
@@ -53,49 +23,17 @@ const AllowlistForm = ({
   field,
 }: RequirementFormProps): JSX.Element => {
   const {
-    setValue,
     formState: { errors },
-    control,
-    register,
     resetField,
   } = useFormContext()
-  const router = useRouter()
-
-  const isHidden = useWatch({ name: `${baseFieldPath}.data.hideAllowlist` })
   const isEditMode = !!field?.id
-
-  const { isDragActive, fileRejections, getRootProps, getInputProps } = useDropzone({
-    multiple: false,
-    accept: { "text/*": [".csv", ".txt"] },
-    onDrop: (accepted) => {
-      if (accepted.length > 0) parseFile(accepted[0])
-    },
-  })
-
-  const type = useWatch({ name: `${baseFieldPath}.type` })
-
-  const parseFile = (file: File) => {
-    const fileReader = new FileReader()
-
-    fileReader.onload = () => {
-      const lines = fileReader.result
-        ?.toString()
-        ?.split("\n")
-        ?.filter((line) => !!line)
-        ?.map((line) => line.trim())
-
-      setValue(`${baseFieldPath}.data.addresses`, lines, { shouldValidate: true })
-    }
-
-    fileReader.readAsText(file)
-  }
 
   const resetFields = () => {
     resetField(`${baseFieldPath}.data.addresses`, { defaultValue: [] })
   }
 
   return (
-    <Stack spacing={4} alignItems="start" {...getRootProps()}>
+    <Stack spacing={4} alignItems="start">
       <FormControl
         isInvalid={!!parseFromObject(errors, baseFieldPath)?.type?.message}
       >
@@ -114,82 +52,7 @@ const AllowlistForm = ({
         </FormErrorMessage>
       </FormControl>
 
-      <FormControl isInvalid={!!fileRejections?.[0]} textAlign="left">
-        <FormLabel>Upload from file</FormLabel>
-
-        <Button as="label" leftIcon={<File />} h={10} maxW={56} cursor="pointer">
-          <input {...getInputProps()} hidden />
-          <Text as="span" display="block" maxW={44} noOfLines={1}>
-            {isDragActive ? "Drop the file here" : "Choose .txt/.csv"}
-          </Text>
-        </Button>
-
-        <FormErrorMessage>
-          {fileRejections?.[0]?.errors?.[0]?.message}
-        </FormErrorMessage>
-      </FormControl>
-
-      <FormControl
-        isInvalid={!!parseFromObject(errors, baseFieldPath)?.data?.addresses}
-      >
-        <Controller
-          control={control}
-          name={`${baseFieldPath}.data.addresses` as const}
-          rules={{
-            validate:
-              type === "ALLOWLIST_EMAIL"
-                ? validateEmailAllowlist
-                : (value_) => {
-                    if (!value_) return
-
-                    const validAddresses = value_.filter(
-                      (address) => address !== "" && isValidAddress(address)
-                    )
-                    // for useBalancy
-                    setValue(`${baseFieldPath}.data.validAddresses`, validAddresses)
-
-                    if (validAddresses.length !== value_.length)
-                      return "Field contains invalid addresses"
-
-                    if (router.route !== "/balancy" && value_.length > 50000)
-                      return `You've added ${value_.length} addresses but the maximum is 50000`
-                  },
-          }}
-          render={({ field: { onChange, onBlur, value: textareaValue, ref } }) => (
-            <Textarea
-              ref={ref}
-              resize="vertical"
-              p={2}
-              minH={64}
-              className="custom-scrollbar"
-              cols={42}
-              wrap="off"
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              spellCheck="false"
-              value={textareaValue?.join("\n") || ""}
-              onChange={(e) => onChange(e.target.value?.split("\n"))}
-              onBlur={onBlur}
-              placeholder="...or paste addresses, each one in a new line"
-            />
-          )}
-        />
-        <FormErrorMessage>
-          {(parseFromObject(errors, baseFieldPath)?.data?.addresses as any)?.message}
-        </FormErrorMessage>
-      </FormControl>
-      {router.asPath !== "/balancy" && (
-        <FormControl pb={3}>
-          <Checkbox
-            fontWeight="medium"
-            {...register(`${baseFieldPath}.data.hideAllowlist`)}
-            checked={isHidden}
-          >
-            Make allowlist private
-          </Checkbox>
-        </FormControl>
-      )}
+      <AllowlistFormInputs baseFieldPath={baseFieldPath} />
     </Stack>
   )
 }

--- a/src/requirements/Allowlist/AllowlistRequirement.tsx
+++ b/src/requirements/Allowlist/AllowlistRequirement.tsx
@@ -1,4 +1,4 @@
-import { Icon, Text, useDisclosure } from "@chakra-ui/react"
+import { HStack, Icon, Text, useDisclosure } from "@chakra-ui/react"
 import { Schemas } from "@guildxyz/types"
 import RequirementConnectButton from "components/[guild]/Requirements/components/ConnectRequirementPlatformButton"
 import Requirement, {
@@ -8,6 +8,14 @@ import { useRequirementContext } from "components/[guild]/Requirements/component
 import Button from "components/common/Button"
 import { ArrowSquareIn, ListPlus } from "phosphor-react"
 import SearchableVirtualListModal from "requirements/common/SearchableVirtualListModal"
+
+function HiddenAllowlistText({ isEmail }: { isEmail: boolean }) {
+  return (
+    <Text color="gray" fontSize="xs" fontWeight="normal">
+      {`Allowlisted ${isEmail ? " email" : ""} addresses are hidden`}
+    </Text>
+  )
+}
 
 const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
   const requirement = useRequirementContext() as Extract<
@@ -26,13 +34,12 @@ const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
       image={<Icon as={ListPlus} boxSize={6} />}
       footer={
         isEmail ? (
-          <RequirementConnectButton />
+          <HStack>
+            <RequirementConnectButton />
+            <HiddenAllowlistText isEmail={isEmail} />
+          </HStack>
         ) : (
-          hideAllowlist && (
-            <Text color="gray" fontSize="xs" fontWeight="normal">
-              {`Allowlisted ${isEmail ? " email" : ""} addresses are hidden`}
-            </Text>
-          )
+          hideAllowlist && <HiddenAllowlistText isEmail={isEmail} />
         )
       }
       {...rest}

--- a/src/requirements/Allowlist/AllowlistRequirement.tsx
+++ b/src/requirements/Allowlist/AllowlistRequirement.tsx
@@ -1,5 +1,6 @@
 import { Icon, Text, useDisclosure } from "@chakra-ui/react"
 import { Schemas } from "@guildxyz/types"
+import RequirementConnectButton from "components/[guild]/Requirements/components/ConnectRequirementPlatformButton"
 import Requirement, {
   RequirementProps,
 } from "components/[guild]/Requirements/components/Requirement"
@@ -24,10 +25,14 @@ const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
     <Requirement
       image={<Icon as={ListPlus} boxSize={6} />}
       footer={
-        hideAllowlist && (
-          <Text color="gray" fontSize="xs" fontWeight="normal">
-            {`Allowlisted ${isEmail ? " email" : ""} addresses are hidden`}
-          </Text>
+        isEmail ? (
+          <RequirementConnectButton />
+        ) : (
+          hideAllowlist && (
+            <Text color="gray" fontSize="xs" fontWeight="normal">
+              {`Allowlisted ${isEmail ? " email" : ""} addresses are hidden`}
+            </Text>
+          )
         )
       }
       {...rest}

--- a/src/requirements/Allowlist/components/AllowlistFormInputs.tsx
+++ b/src/requirements/Allowlist/components/AllowlistFormInputs.tsx
@@ -59,7 +59,10 @@ export default function AllowlistFormInputs({
         ?.filter((line) => !!line)
         ?.map((line) => line.trim())
 
-      setValue(`${baseFieldPath}.data.addresses`, lines, { shouldValidate: true })
+      setValue(`${baseFieldPath}.data.addresses`, lines, {
+        shouldValidate: true,
+        shouldDirty: true,
+      })
     }
 
     fileReader.readAsText(file)

--- a/src/requirements/Allowlist/components/AllowlistFormInputs.tsx
+++ b/src/requirements/Allowlist/components/AllowlistFormInputs.tsx
@@ -1,0 +1,158 @@
+import {
+  Checkbox,
+  FormControl,
+  FormLabel,
+  Stack,
+  Text,
+  Textarea,
+} from "@chakra-ui/react"
+import { isValidAddress } from "components/[guild]/EditGuild/components/Admins/Admins"
+import Button from "components/common/Button"
+import FormErrorMessage from "components/common/FormErrorMessage"
+import useDropzone from "hooks/useDropzone"
+import { useRouter } from "next/router"
+import { File } from "phosphor-react"
+import { Controller, useFormContext, useWatch } from "react-hook-form"
+import parseFromObject from "utils/parseFromObject"
+import { z } from "zod"
+
+function validateEmailAllowlist(toValidate: string[]) {
+  if (!toValidate) return
+
+  const containsEmpty = toValidate.some((address) => address === "")
+
+  if (containsEmpty) {
+    return "Field contains empty line"
+  }
+
+  const invalidEmails = toValidate.filter(
+    (address) => !z.string().email().safeParse(address).success
+  )
+
+  if (invalidEmails.length > 0) {
+    return `Field contains invalid email address: ${invalidEmails[0]}`
+  }
+}
+
+export default function AllowlistFormInputs({
+  baseFieldPath,
+}: {
+  baseFieldPath: string
+}) {
+  const {
+    setValue,
+    formState: { errors },
+    control,
+    register,
+  } = useFormContext()
+  const router = useRouter()
+
+  const isHidden = useWatch({ name: `${baseFieldPath}.data.hideAllowlist` })
+
+  const parseFile = (file: File) => {
+    const fileReader = new FileReader()
+
+    fileReader.onload = () => {
+      const lines = fileReader.result
+        ?.toString()
+        ?.split("\n")
+        ?.filter((line) => !!line)
+        ?.map((line) => line.trim())
+
+      setValue(`${baseFieldPath}.data.addresses`, lines, { shouldValidate: true })
+    }
+
+    fileReader.readAsText(file)
+  }
+
+  const { isDragActive, fileRejections, getRootProps, getInputProps } = useDropzone({
+    multiple: false,
+    accept: { "text/*": [".csv", ".txt"] },
+    onDrop: (accepted) => {
+      if (accepted.length > 0) parseFile(accepted[0])
+    },
+  })
+
+  const type = useWatch({ name: `${baseFieldPath}.type` })
+
+  return (
+    <Stack spacing={4} alignItems="start" {...getRootProps()}>
+      <FormControl isInvalid={!!fileRejections?.[0]} textAlign="left">
+        <FormLabel>Upload from file</FormLabel>
+
+        <Button as="label" leftIcon={<File />} h={10} maxW={56} cursor="pointer">
+          <input {...getInputProps()} hidden />
+          <Text as="span" display="block" maxW={44} noOfLines={1}>
+            {isDragActive ? "Drop the file here" : "Choose .txt/.csv"}
+          </Text>
+        </Button>
+
+        <FormErrorMessage>
+          {fileRejections?.[0]?.errors?.[0]?.message}
+        </FormErrorMessage>
+      </FormControl>
+
+      <FormControl
+        isInvalid={!!parseFromObject(errors, baseFieldPath)?.data?.addresses}
+      >
+        <Controller
+          control={control}
+          name={`${baseFieldPath}.data.addresses` as const}
+          rules={{
+            validate:
+              type === "ALLOWLIST_EMAIL"
+                ? validateEmailAllowlist
+                : (value_) => {
+                    if (!value_) return
+
+                    const validAddresses = value_.filter(
+                      (address) => address !== "" && isValidAddress(address)
+                    )
+                    // for useBalancy
+                    setValue(`${baseFieldPath}.data.validAddresses`, validAddresses)
+
+                    if (validAddresses.length !== value_.length)
+                      return "Field contains invalid addresses"
+
+                    if (router.route !== "/balancy" && value_.length > 50000)
+                      return `You've added ${value_.length} addresses but the maximum is 50000`
+                  },
+          }}
+          render={({ field: { onChange, onBlur, value: textareaValue, ref } }) => (
+            <Textarea
+              ref={ref}
+              resize="vertical"
+              p={2}
+              minH={64}
+              className="custom-scrollbar"
+              cols={42}
+              wrap="off"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck="false"
+              value={textareaValue?.join("\n") || ""}
+              onChange={(e) => onChange(e.target.value?.split("\n"))}
+              onBlur={onBlur}
+              placeholder="...or paste addresses, each one in a new line"
+            />
+          )}
+        />
+        <FormErrorMessage>
+          {(parseFromObject(errors, baseFieldPath)?.data?.addresses as any)?.message}
+        </FormErrorMessage>
+      </FormControl>
+      {router.asPath !== "/balancy" && (
+        <FormControl pb={3}>
+          <Checkbox
+            fontWeight="medium"
+            {...register(`${baseFieldPath}.data.hideAllowlist`)}
+            checked={isHidden}
+          >
+            Make allowlist private
+          </Checkbox>
+        </FormControl>
+      )}
+    </Stack>
+  )
+}

--- a/src/requirements/Email/EmailForm.tsx
+++ b/src/requirements/Email/EmailForm.tsx
@@ -17,7 +17,7 @@ const guildRequirementTypes = [
     value: "EMAIL_DOMAIN",
   },
   {
-    label: "Be on listed emails",
+    label: "Be included in email allowlist",
     value: "ALLOWLIST_EMAIL",
   },
 ] as const

--- a/src/requirements/Email/EmailForm.tsx
+++ b/src/requirements/Email/EmailForm.tsx
@@ -4,6 +4,7 @@ import FormErrorMessage from "components/common/FormErrorMessage"
 import { useEffect } from "react"
 import { useFormContext, useFormState, useWatch } from "react-hook-form"
 import { RequirementFormProps } from "requirements"
+import AllowlistFormInputs from "requirements/Allowlist/components/AllowlistFormInputs"
 import parseFromObject from "utils/parseFromObject"
 
 const guildRequirementTypes = [
@@ -14,6 +15,10 @@ const guildRequirementTypes = [
   {
     label: "Verify an email with domain",
     value: "EMAIL_DOMAIN",
+  },
+  {
+    label: "Be on listed emails",
+    value: "ALLOWLIST_EMAIL",
   },
 ] as const
 
@@ -50,6 +55,10 @@ const EmailForm = ({ baseFieldPath, field }: RequirementFormProps): JSX.Element 
           {parseFromObject(errors, baseFieldPath)?.type?.message}
         </FormErrorMessage>
       </FormControl>
+
+      {selected?.value === "ALLOWLIST_EMAIL" && (
+        <AllowlistFormInputs baseFieldPath={baseFieldPath} />
+      )}
 
       {selected?.value === "EMAIL_DOMAIN" && (
         <>


### PR DESCRIPTION
[Linear](https://linear.app/guildxyz/issue/GUILD-2599/smaller-email-allowlist-improvements) - [Discord](https://discord.com/channels/697041998728659035/1221827375910621286/1222193169320382606)

- Show ALLOWLIST_EMAIL as an option under the email category as well
- Show connect button on requirement card
  - For this, I've moved some code to a separate component
- Change EMAIL colorScheme to blue