### PR TITLE
`useGuild` & `useRole` optimization

### DIFF
--- a/src/components/[guild]/hooks/useGuild.ts
+++ b/src/components/[guild]/hooks/useGuild.ts
@@ -3,7 +3,7 @@ import useSWRWithOptionalAuth, {
 } from "hooks/useSWRWithOptionalAuth"
 import { useRouter } from "next/router"
 import { useEffect } from "react"
-import { useSWRConfig } from "swr"
+import { unstable_serialize, useSWRConfig } from "swr"
 import useSWRImmutable from "swr/immutable"
 import { Guild, SimpleGuild } from "types"
 
@@ -49,15 +49,16 @@ const useSimpleGuild = (guildId?: string | number) => {
   const id = guildId ?? router.query.guild
 
   const { cache } = useSWRConfig()
-  const guildFromCache = cache.get(`/v2/guilds/guild-page/${id}`)
-    ?.data as SimpleGuild
+  const guildPageFromCache = cache.get(
+    unstable_serialize([`/v2/guilds/guild-page/${id}`, { method: "GET", body: {} }])
+  )?.data as SimpleGuild
 
   const { data, ...swrProps } = useSWRImmutable<SimpleGuild>(
-    id && !guildFromCache ? `/v2/guilds/${id}` : null
+    id && !guildPageFromCache ? `/v2/guilds/${id}` : null
   )
 
   return {
-    ...(guildFromCache ?? data),
+    ...(guildPageFromCache ?? data),
     ...swrProps,
   }
 }

--- a/src/components/[guild]/hooks/useGuild.ts
+++ b/src/components/[guild]/hooks/useGuild.ts
@@ -1,5 +1,8 @@
-import useSWRWithOptionalAuth from "hooks/useSWRWithOptionalAuth"
+import useSWRWithOptionalAuth, {
+  mutateOptionalAuthSWRKey,
+} from "hooks/useSWRWithOptionalAuth"
 import { useRouter } from "next/router"
+import { useEffect } from "react"
 import { useSWRConfig } from "swr"
 import useSWRImmutable from "swr/immutable"
 import { Guild, SimpleGuild } from "types"
@@ -14,6 +17,23 @@ const useGuild = (guildId?: string | number) => {
     undefined,
     false
   )
+
+  // If we fetch guild by id, we populate the urlName cache too and vice versa
+  useEffect(() => {
+    if (!data) return
+
+    if (typeof id === "string") {
+      mutateOptionalAuthSWRKey(`/v2/guilds/guild-page/${data.id}`, () => data, {
+        revalidate: false,
+      })
+    }
+
+    if (typeof id === "number") {
+      mutateOptionalAuthSWRKey(`/v2/guilds/guild-page/${data.urlName}`, () => data, {
+        revalidate: false,
+      })
+    }
+  }, [data, id])
 
   return {
     ...data,

--- a/src/components/[guild]/hooks/useRole.ts
+++ b/src/components/[guild]/hooks/useRole.ts
@@ -1,19 +1,28 @@
 import useSWRImmutable from "swr/immutable"
 import { SimpleRole } from "types"
 import { useFetcherWithSign } from "utils/fetcher"
+import useGuild from "./useGuild"
 
 const useRole = (guildId: number | string, roleId: number) => {
   const url = `/v2/guilds/${guildId}/roles/${roleId}`
 
+  /**
+   * If the role is from the current guild, we don't need to fetch it separately,
+   * since we already have the necessary data in the `useGuild` SWR cache
+   */
+  const { id, roles } = useGuild()
+  const isFromCurrentGuild = guildId === id
+  const shouldFetch = !!guildId && !!roleId && !isFromCurrentGuild
+
   const { data: unauthenticatedData, isLoading: isUnauthenticatedRequestLoading } =
-    useSWRImmutable<SimpleRole>(guildId && roleId ? url : null, {
+    useSWRImmutable<SimpleRole>(shouldFetch ? url : null, {
       shouldRetryOnError: false,
     })
 
   const fetcherWithSign = useFetcherWithSign()
   const { data: authenticatedData, isLoading: isAuthenticatedRequestLoading } =
     useSWRImmutable<SimpleRole>(
-      guildId && roleId && !isUnauthenticatedRequestLoading && !unauthenticatedData
+      shouldFetch && !isUnauthenticatedRequestLoading && !unauthenticatedData
         ? [url, { method: "GET", body: {} }]
         : null,
       fetcherWithSign,
@@ -23,7 +32,9 @@ const useRole = (guildId: number | string, roleId: number) => {
     )
 
   return {
-    ...(unauthenticatedData || authenticatedData),
+    ...(isFromCurrentGuild
+      ? roles.find((role) => role.id === roleId)
+      : unauthenticatedData || authenticatedData),
     isLoading: isUnauthenticatedRequestLoading || isAuthenticatedRequestLoading,
   }
 }


### PR DESCRIPTION
Sometimes we fetched the guild / role unnecessarily in the guild requirement display component, so I added some extra logic to these hooks: we check the `guild-page` cache before fetching the entities, and if we find the necessary data in this cache, we just return it from there.