### PR TITLE
feat: messaging rate limit alert

### DIFF
--- a/src/components/[guild]/EditGuild/components/FeatureFlags.tsx
+++ b/src/components/[guild]/EditGuild/components/FeatureFlags.tsx
@@ -9,7 +9,6 @@ const FEATURE_FLAGS = [
   "GUILD_CREDENTIAL",
   "CRM",
   "GUILD_QUEUES",
-  "MESSAGING",
   "FORMS",
   "PERIODIC_SYNC",
 ] as const

--- a/src/components/[guild]/Tabs/GuildTabs.tsx
+++ b/src/components/[guild]/Tabs/GuildTabs.tsx
@@ -1,4 +1,3 @@
-import { IntercomTrigger } from "components/_app/IntercomProvider"
 import { usePostHogContext } from "components/_app/PostHogProvider"
 import { PlatformType } from "types"
 import { useAccessedGuildPoints } from "../AccessHub/hooks/useAccessedGuildPoints"
@@ -91,21 +90,11 @@ const GuildTabs = ({ activeTab, ...rest }: Props): JSX.Element => {
           Analytics
         </TabButton>
       )}
-      {isAdmin &&
-        (featureFlags.includes("MESSAGING") ? (
-          <TabButton
-            href={`/${urlName}/messages`}
-            isActive={activeTab === "MESSAGES"}
-          >
-            Messages
-          </TabButton>
-        ) : (
-          <>
-            <IntercomTrigger data-intercom-selector="messages-tab-button">
-              <TabButton>Messages</TabButton>
-            </IntercomTrigger>
-          </>
-        ))}
+      {isAdmin && (
+        <TabButton href={`/${urlName}/messages`} isActive={activeTab === "MESSAGES"}>
+          Messages
+        </TabButton>
+      )}
     </Tabs>
   )
 }

--- a/src/components/[guild]/messages/SendNewMessage/SendNewMessage.tsx
+++ b/src/components/[guild]/messages/SendNewMessage/SendNewMessage.tsx
@@ -161,7 +161,7 @@ const SendNewMessage = (props: ButtonProps) => {
                     <Link href="https://web3inbox.com" colorScheme="blue" isExternal>
                       Web3Inbox
                     </Link>
-                    {`. They can do it from the notifications menu easily!`}
+                    {` - they can do it from the top right bell icon!`}
                   </Text>
                 </Stack>
 
@@ -191,7 +191,6 @@ const SendNewMessage = (props: ButtonProps) => {
             >
               <Button
                 ml="auto"
-                h={10}
                 colorScheme="green"
                 rightIcon={<PaperPlaneRight />}
                 onClick={handleSubmit(onSubmit)}

--- a/src/components/[guild]/messages/SendNewMessage/SendNewMessage.tsx
+++ b/src/components/[guild]/messages/SendNewMessage/SendNewMessage.tsx
@@ -3,6 +3,7 @@ import {
   ButtonProps,
   FormControl,
   FormLabel,
+  HStack,
   ModalBody,
   ModalCloseButton,
   ModalContent,
@@ -13,7 +14,6 @@ import {
   Stack,
   Text,
   Textarea,
-  Tooltip,
   useColorModeValue,
   useDisclosure,
 } from "@chakra-ui/react"
@@ -119,7 +119,11 @@ const SendNewMessage = (props: ButtonProps) => {
                 )}
 
                 <Stack>
-                  <FormControl isRequired isInvalid={!!errors.roleIds}>
+                  <FormControl
+                    isRequired
+                    isInvalid={!!errors.roleIds}
+                    isDisabled={isSendDisabled}
+                  >
                     <FormLabel>Recipient roles</FormLabel>
                     <RoleIdsSelect />
                     <FormErrorMessage>{errors.roleIds?.message}</FormErrorMessage>
@@ -165,7 +169,11 @@ const SendNewMessage = (props: ButtonProps) => {
                   </Text>
                 </Stack>
 
-                <FormControl isRequired isInvalid={!!errors.message}>
+                <FormControl
+                  isRequired
+                  isInvalid={!!errors.message}
+                  isDisabled={isSendDisabled}
+                >
                   <FormLabel>Message</FormLabel>
                   <Textarea
                     placeholder="Write your message here"
@@ -185,13 +193,13 @@ const SendNewMessage = (props: ButtonProps) => {
           </ModalBody>
 
           <ModalFooter>
-            <Tooltip
-              label="You can send one message per day, please check back later!"
-              isDisabled={!isSendDisabled}
-            >
+            <HStack justifyContent={"space-between"} w="full" gap="6">
+              <Text fontSize="sm" colorScheme={"gray"}>
+                You can only send one message per day
+              </Text>
               <Button
-                ml="auto"
                 colorScheme="green"
+                flexShrink={0}
                 rightIcon={<PaperPlaneRight />}
                 onClick={handleSubmit(onSubmit)}
                 isLoading={isLoading}
@@ -200,7 +208,7 @@ const SendNewMessage = (props: ButtonProps) => {
               >
                 Send
               </Button>
-            </Tooltip>
+            </HStack>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/src/components/[guild]/messages/SendNewMessage/components/MessagingRateLimitAlert.tsx
+++ b/src/components/[guild]/messages/SendNewMessage/components/MessagingRateLimitAlert.tsx
@@ -1,0 +1,34 @@
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Stack,
+} from "@chakra-ui/react"
+
+type Props = {
+  latestMessageCreatedAt: number
+}
+
+const MessagingRateLimitAlert = ({ latestMessageCreatedAt }: Props) => {
+  const now = Date.now()
+  const timeDiff = now - latestMessageCreatedAt
+  const rateLimitEnd = new Date(now + timeDiff).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+  })
+
+  return (
+    <Alert status="info">
+      <AlertIcon />
+      <Stack position="relative" top={1} spacing={1}>
+        <AlertTitle>You can send 1 message per day</AlertTitle>
+        <AlertDescription>{`You'll be able to send your next message at ${rateLimitEnd}`}</AlertDescription>
+      </Stack>
+    </Alert>
+  )
+}
+export default MessagingRateLimitAlert

--- a/src/components/[guild]/messages/SendNewMessage/components/MessagingRateLimitAlert.tsx
+++ b/src/components/[guild]/messages/SendNewMessage/components/MessagingRateLimitAlert.tsx
@@ -24,10 +24,10 @@ const MessagingRateLimitAlert = ({ latestMessageCreatedAt }: Props) => {
 
   return (
     <Alert status="info">
-      <AlertIcon />
-      <Stack position="relative" top={1} spacing={1}>
-        <AlertTitle>You can send 1 message per day</AlertTitle>
-        <AlertDescription>{`You'll be able to send your next message at ${rateLimitEnd}`}</AlertDescription>
+      <AlertIcon mt="-1px" />
+      <Stack spacing={1}>
+        <AlertTitle>You can only send one message per day</AlertTitle>
+        <AlertDescription>{`You'll be able to send your next message on ${rateLimitEnd}`}</AlertDescription>
       </Stack>
     </Alert>
   )

--- a/src/components/[guild]/messages/SendNewMessage/components/MessagingRateLimitAlert.tsx
+++ b/src/components/[guild]/messages/SendNewMessage/components/MessagingRateLimitAlert.tsx
@@ -5,15 +5,16 @@ import {
   AlertTitle,
   Stack,
 } from "@chakra-ui/react"
+import { DAY_IN_MS } from "utils/formatRelativeTimeFromNow"
 
 type Props = {
   latestMessageCreatedAt: number
 }
 
 const MessagingRateLimitAlert = ({ latestMessageCreatedAt }: Props) => {
-  const now = Date.now()
-  const timeDiff = now - latestMessageCreatedAt
-  const rateLimitEnd = new Date(now + timeDiff).toLocaleDateString("en-US", {
+  const rateLimitEnd = new Date(
+    latestMessageCreatedAt + DAY_IN_MS
+  ).toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",
     day: "numeric",

--- a/src/components/common/Layout/components/Account/components/Web3Inbox/Web3InboxMessage.tsx
+++ b/src/components/common/Layout/components/Account/components/Web3Inbox/Web3InboxMessage.tsx
@@ -106,7 +106,7 @@ const Web3InboxMessage = ({
               <Text>{body}</Text>
             </Stack>
           </ModalBody>
-          <ModalFooter pt="0">
+          <ModalFooter pt="0" pb="8">
             <Text fontFamily="body" colorScheme="gray" fontSize="sm">
               {prettyDate}
             </Text>


### PR DESCRIPTION
We'd like to release the messaging feature for every guild, but we have pretty strict rate limits, so we'll allow guild admins to send 1 message per day (per guild) for now & display an info alert for them if they reached this limit.