### PR TITLE
feat: useAutoReconnect hook

### DIFF
--- a/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
+++ b/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
@@ -4,6 +4,7 @@ import PlatformMergeErrorAlert from "./components/PlatformMergeErrorAlert"
 import WalletSelectorModal, {
   walletSelectorModalAtom,
 } from "./components/WalletSelectorModal"
+import useAutoReconnect from "./hooks/useAutoReconnect"
 import useConnectFromLocalStorage from "./hooks/useConnectFromLocalStorage"
 
 const Web3ConnectionManager = () => {
@@ -11,6 +12,7 @@ const Web3ConnectionManager = () => {
     walletSelectorModalAtom
   )
 
+  useAutoReconnect()
   useConnectFromLocalStorage()
 
   return (

--- a/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
+++ b/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect } from "react"
+import { useConfig, useConnectors } from "wagmi"
+
+const waitForRetry = () =>
+  new Promise((resolve) => setTimeout(() => resolve(true), 200))
+
+const useAutoReconnect = () => {
+  const connectors = useConnectors()
+  const config = useConfig()
+
+  const handleReconnect = useCallback(async () => {
+    if (!config || !connectors) return
+
+    let connected = false
+
+    const recentConnectorId = await config.storage.getItem("recentConnectorId")
+    if (!recentConnectorId) return
+
+    const connectorToReconnect = connectors.find(
+      (connector) => connector.id === recentConnectorId
+    )
+    if (!connectorToReconnect) return
+
+    config.setState((prevState) => ({ ...prevState, status: "reconnecting" }))
+
+    const provider = await connectorToReconnect.getProvider()
+    if (!provider) return
+
+    let isAuthorized = false
+    let retryCount = 0
+
+    while (!isAuthorized && retryCount < 3) {
+      // isAuthorized is false most of the time, so we retry 3 times
+      await waitForRetry()
+      retryCount++
+      isAuthorized = await connectorToReconnect.isAuthorized()
+    }
+
+    if (!isAuthorized) return
+
+    const data = await connectorToReconnect
+      .connect({
+        isReconnecting: true,
+      })
+      .catch(() => null)
+
+    if (!data) return
+
+    connectorToReconnect.emitter.off("connect", config._internal.events.connect)
+    connectorToReconnect.emitter.on("change", config._internal.events.change)
+    connectorToReconnect.emitter.on("disconnect", config._internal.events.disconnect)
+
+    config.setState((prevState) => ({
+      ...prevState,
+      current: connectorToReconnect.uid,
+      connections: new Map(prevState.connections ?? []).set(
+        connectorToReconnect.uid,
+        {
+          accounts: data.accounts,
+          chainId: data.chainId,
+          connector: connectorToReconnect,
+        }
+      ),
+    }))
+
+    connected = true
+
+    if (
+      config.state.status === "reconnecting" ||
+      config.state.status === "connecting"
+    ) {
+      // If connecting didn't succeed, set to disconnected
+      if (!connected)
+        config.setState((x) => ({
+          ...x,
+          connections: new Map(),
+          current: undefined,
+          status: "disconnected",
+        }))
+      else config.setState((x) => ({ ...x, status: "connected" }))
+    }
+  }, [config, connectors])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    handleReconnect()
+  }, [handleReconnect])
+}
+
+export default useAutoReconnect

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -112,10 +112,7 @@ const App = ({
           }}
         >
           <SWRConfig value={{ fetcher: fetcherForSWR }}>
-            <WagmiProvider
-              config={wagmiConfig}
-              reconnectOnMount={!process.env.NEXT_PUBLIC_MOCK_CONNECTOR}
-            >
+            <WagmiProvider config={wagmiConfig} reconnectOnMount={false}>
               <QueryClientProvider client={queryClient}>
                 <FuelProvider>
                   <PostHogProvider>


### PR DESCRIPTION
Unfortunately wagmi's `reconnectOnMount` was pretty unreliable, and the `isConnected` prop wasn't in sync with the `status` prop either, so we decided to implement a custom `useAutoReconnect` hook instead.