### PR TITLE
refactor: improve the link address flow

### DIFF
--- a/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
+++ b/src/components/_app/Web3ConnectionManager/Web3ConnectionManager.tsx
@@ -1,6 +1,7 @@
 import ClientOnly from "components/common/ClientOnly"
 import { useAtom } from "jotai"
 import PlatformMergeErrorAlert from "./components/PlatformMergeErrorAlert"
+import WalletLinkHelperModal from "./components/WalletLinkHelperModal"
 import WalletSelectorModal, {
   walletSelectorModalAtom,
 } from "./components/WalletSelectorModal"
@@ -22,6 +23,7 @@ const Web3ConnectionManager = () => {
         onOpen={() => setIsWalletSelectorModalOpen(true)}
         onClose={() => setIsWalletSelectorModalOpen(false)}
       />
+      <WalletLinkHelperModal />
       <PlatformMergeErrorAlert />
     </ClientOnly>
   )

--- a/src/components/_app/Web3ConnectionManager/components/WalletLinkHelperModal.tsx
+++ b/src/components/_app/Web3ConnectionManager/components/WalletLinkHelperModal.tsx
@@ -1,0 +1,50 @@
+import {
+  Box,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react"
+import LogicDivider from "components/[guild]/LogicDivider"
+import Button from "components/common/Button"
+import { Modal } from "components/common/Modal"
+import { atom, useAtom } from "jotai"
+import { SignOut } from "phosphor-react"
+
+export const walletLinkHelperModalAtom = atom(false)
+
+const WalletLinkHelperModal = () => {
+  const [isWalletLinkHelperModalOpen, setIsWalletLinkModalOpen] = useAtom(
+    walletLinkHelperModalAtom
+  )
+
+  const onClose = () => setIsWalletLinkModalOpen(false)
+
+  return (
+    <Modal isOpen={isWalletLinkHelperModalOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalCloseButton />
+        <ModalHeader>Link address</ModalHeader>
+        <ModalBody>
+          <Text mt="-3">
+            Please switch to the account you want to link and connect with it in your
+            wallet!
+          </Text>
+          <Box borderRadius={"lg"} overflow="hidden" mt="4" minH="448px">
+            <video src="/videos/metamask-switch-account.webm" muted autoPlay loop>
+              Your browser does not support the HTML5 video tag.
+            </video>
+          </Box>
+          <LogicDivider logic="OR" my="1" />
+          <Button onClick={onClose} w="full" rightIcon={<SignOut />}>
+            Connect another wallet
+          </Button>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}
+export default WalletLinkHelperModal

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -21,13 +21,14 @@ import { addressLinkParamsAtom } from "components/common/Layout/components/Accou
 import { Modal } from "components/common/Modal"
 import ModalButton from "components/common/ModalButton"
 import useSetKeyPair from "hooks/useSetKeyPair"
-import { useAtom } from "jotai"
+import { useAtom, useSetAtom } from "jotai"
 import { useRouter } from "next/router"
 import { ArrowLeft, ArrowSquareOut } from "phosphor-react"
 import { useEffect } from "react"
 import { useAccount, useConnect, type Connector } from "wagmi"
 import { WAAS_CONNECTOR_ID } from "wagmiConfig/waasConnector"
 import useWeb3ConnectionManager from "../../hooks/useWeb3ConnectionManager"
+import { walletLinkHelperModalAtom } from "../WalletLinkHelperModal"
 import AccountButton from "./components/AccountButton"
 import ConnectorButton from "./components/ConnectorButton"
 import FuelConnectorButtons from "./components/FuelConnectorButtons"
@@ -127,6 +128,12 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
   const shouldShowVerify =
     isWeb3Connected && (!!publicUserError || (!!id && !keyPair))
 
+  const setIsWalletLinkHelperModalOpen = useSetAtom(walletLinkHelperModalAtom)
+  useEffect(() => {
+    if (!isWeb3Connected) return
+    setIsWalletLinkHelperModalOpen(false)
+  }, [isWeb3Connected, setIsWalletLinkHelperModalOpen])
+
   return (
     <Modal
       isOpen={isOpen}
@@ -192,7 +199,7 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
             <AccountButton />
           ) : (
             <Stack spacing="0">
-              {!connector && (
+              {!connector && !addressLinkParams?.userId && (
                 <>
                   <GoogleLoginButton />
                   <Text

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/ConnectorButton.tsx
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/ConnectorButton.tsx
@@ -2,8 +2,11 @@ import { ButtonProps, Center, Icon, Img } from "@chakra-ui/react"
 import { useUserPublic } from "components/[guild]/hooks/useUser"
 import useConnectorNameAndIcon from "components/_app/Web3ConnectionManager/hooks/useConnectorNameAndIcon"
 import Button from "components/common/Button"
+import { addressLinkParamsAtom } from "components/common/Layout/components/Account/components/AccountModal/components/LinkAddressButton"
+import { useAtomValue, useSetAtom } from "jotai"
 import { Wallet } from "phosphor-react"
 import { useAccount, type Connector } from "wagmi"
+import { walletLinkHelperModalAtom } from "../../WalletLinkHelperModal"
 
 type Props = {
   connector: Connector
@@ -38,10 +41,16 @@ const ConnectorButton = ({
 
   const { connectorName, connectorIcon } = useConnectorNameAndIcon(connector)
 
+  const addressLinkParams = useAtomValue(addressLinkParamsAtom)
+  const setIsWalletLinkHelperModalOpen = useSetAtom(walletLinkHelperModalAtom)
+
   return (
     <Button
       data-wagmi-connector-id={connector.id}
-      onClick={() => connect({ connector })}
+      onClick={() => {
+        if (addressLinkParams?.userId) setIsWalletLinkHelperModalOpen(true)
+        connect({ connector })
+      }}
       leftIcon={
         connectorIcon ? (
           <Center boxSize={6}>

--- a/src/components/common/Layout/components/Account/components/AccountModal/components/LinkAddressButton.tsx
+++ b/src/components/common/Layout/components/Account/components/AccountModal/components/LinkAddressButton.tsx
@@ -1,23 +1,9 @@
-import {
-  Box,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalHeader,
-  ModalOverlay,
-  Text,
-  useDisclosure,
-} from "@chakra-ui/react"
-import LogicDivider from "components/[guild]/LogicDivider"
 import useUser from "components/[guild]/hooks/useUser"
 import { walletSelectorModalAtom } from "components/_app/Web3ConnectionManager/components/WalletSelectorModal"
 import useWeb3ConnectionManager from "components/_app/Web3ConnectionManager/hooks/useWeb3ConnectionManager"
 import Button from "components/common/Button"
-import { Modal } from "components/common/Modal"
 import { atom, useSetAtom } from "jotai"
-import { Plus, SignOut } from "phosphor-react"
-import { useState } from "react"
-import { useWalletClient } from "wagmi"
+import { Plus } from "phosphor-react"
 
 export type AddressLinkParams = {
   userId?: number
@@ -29,78 +15,28 @@ export const addressLinkParamsAtom = atom<AddressLinkParams>({
 })
 
 const LinkAddressButton = (props) => {
-  const [isLoading, setIsLoading] = useState(false)
   const { id } = useUser()
 
   const { address, disconnect } = useWeb3ConnectionManager()
 
-  const { data: walletClient } = useWalletClient()
-
-  const { isOpen, onOpen, onClose } = useDisclosure()
   const setAddressLinkParams = useSetAtom(addressLinkParamsAtom)
   const setIsWalletSelectorModalOpen = useSetAtom(walletSelectorModalAtom)
-
-  if (!id) return null
-
-  const onClick = async () => {
-    setIsLoading(true)
-    onOpen()
-    setAddressLinkParams({ userId: id, address })
-
-    try {
-      await walletClient.requestPermissions({ eth_accounts: {} })
-    } catch {
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  const handleClose = () => {
-    onClose()
-    setIsLoading(false)
-  }
-
-  const handleLogout = () => {
-    handleClose()
-    disconnect()
-
-    setIsWalletSelectorModalOpen(true)
-  }
 
   return (
     <>
       <Button
         leftIcon={<Plus />}
         size="sm"
-        onClick={onClick}
-        isLoading={isLoading}
+        onClick={() => {
+          setAddressLinkParams({ userId: id, address })
+          disconnect()
+          setIsWalletSelectorModalOpen(true)
+        }}
         loadingText="Check your wallet"
         {...props}
       >
         Link address
       </Button>
-      <Modal isOpen={isOpen} onClose={handleClose}>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalCloseButton />
-          <ModalHeader>Link address</ModalHeader>
-          <ModalBody>
-            <Text mt="-3">
-              Please switch to the account you want to link and connect with it in
-              your wallet!
-            </Text>
-            <Box borderRadius={"lg"} overflow="hidden" mt="4" minH="448px">
-              <video src="/videos/metamask-switch-account.webm" muted autoPlay loop>
-                Your browser does not support the HTML5 video tag.
-              </video>
-            </Box>
-            <LogicDivider logic="OR" my="1" />
-            <Button onClick={handleLogout} w="full" rightIcon={<SignOut />}>
-              Connect another wallet
-            </Button>
-          </ModalBody>
-        </ModalContent>
-      </Modal>
     </>
   )
 }


### PR DESCRIPTION
Move the modal with the helper video to the `Web3ConnectionManager` (so we only render it once), and also showing it only when the user already picked a connector. We also don't trigger an EVM wallet connection when the user starts the link address flow, because it was confusing for Fuel users. 