### PR TITLE
fix(waas connector): chain handling

### DIFF
--- a/src/wagmiConfig/waasConnector.ts
+++ b/src/wagmiConfig/waasConnector.ts
@@ -169,7 +169,7 @@ export default function waasConnector(options: InitializeWaasOptions) {
 
     async switchChain(parameters) {
       chainId = parameters.chainId
-      await this.getWalletClient({ chainId })
+      await this.getClient({ chainId })
       const chain = chains.find(({ id }) => id === chainId)
       this.onChainChanged(chainId)
       return chain
@@ -180,8 +180,8 @@ export default function waasConnector(options: InitializeWaasOptions) {
       // else emitter.emit("change", { account: currentAddress.address })
     },
 
-    async onChainChanged(_newChainId) {
-      // emitter.emit("change", { chain: { id: +newChainId, unsupported: false } })
+    async onChainChanged(newChainId) {
+      emitter.emit("change", { chainId: +newChainId })
     },
 
     async onDisconnect(_error) {

--- a/src/wagmiConfig/waasConnector.ts
+++ b/src/wagmiConfig/waasConnector.ts
@@ -98,7 +98,7 @@ export default function waasConnector(options: InitializeWaasOptions) {
 
       return {
         accounts: [this.currentAddress.address],
-        chainId: config?.chainId,
+        chainId,
       }
     },
 


### PR DESCRIPTION
[BugSnag](https://app.bugsnag.com/guild-1/guild-dot-xyz/errors/6620f998aac2d10008772921?filters%5Bevent.unhandled%5D=true&filters%5Bevent.since%5D=30d&filters%5Bapp.release_stage%5D=production) - [Linear](https://linear.app/guildxyz/issue/GUILD-2818/waas-debugging)

- Issue 1: It wasn't possible to switch chains when connecting with WaaS
  - This one comes from BugSnag
- Issue 2: The initial chain was `undefined` instead of `1`