### PR TITLE
fix(waas): use non-dyamic import

### DIFF
--- a/fixWaas.js
+++ b/fixWaas.js
@@ -1,0 +1,28 @@
+const { readFileSync, writeFileSync } = require("fs")
+
+const basePath = "./node_modules/@coinbase/waas-sdk-web/dist"
+
+const paths = [
+  `${basePath}/mpc.js`,
+  `${basePath}/waas.js`,
+  `${basePath}/perf.js`,
+  `${basePath}/bugsnag.js`,
+  `${basePath}/core/http.js`,
+]
+console.log(`[fixWaas] - ${paths.length} files will be processed`)
+
+for (const path of paths) {
+  console.log("\n[fixWaas] - Processing:", path)
+
+  try {
+    const content = readFileSync(path).toString()
+    const newContent = content
+      .replace(`versions.json";`, `versions.json" assert { type: "json" };`)
+      .replace(`versions.json';`, `versions.json' assert { type: "json" };`)
+
+    writeFileSync(path, newContent)
+    console.log("[fixWaas] - Processed")
+  } catch (error) {
+    console.log("[fixWaas] - Failed")
+  }
+}

--- a/fixWaas.js
+++ b/fixWaas.js
@@ -1,3 +1,9 @@
+/**
+ * This script is temporarily needed for making a small transformation on the WaaS
+ * SDK-s, which allows us to non-dynamically import these packages. This script is
+ * executed at postinstall. If you encounter ERR_IMPORT_ASSERTION_TYPE_MISSING
+ * TypeError at build, you should probably run an 'npm install'
+ */
 const { readFileSync, writeFileSync } = require("fs")
 
 const basePath = "./node_modules/@coinbase/waas-sdk-web/dist"

--- a/mockWaas.js
+++ b/mockWaas.js
@@ -15,7 +15,7 @@ export type Waas = any;
 export type Wallet = any
 export enum ProtocolFamily { EVM }
 export function InitializeWaas(_) {}
-export function Logout() {}
+export async function Logout() {}
 `
 
 const viemMock = `

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "cypress run",
     "test:mobile": "cypress run --config viewportWidth=375,viewportHeight=667",
     "snyk-protect": "snyk-protect",
-    "postinstall": "npx dotenv-cli -e .env.local -- bash -c 'npm i --no-save --ignore-scripts $WAAS_WEB_URL $WAAS_VIEM_URL'"
+    "postinstall": "npx dotenv-cli -e .env.local -- bash -c 'npm i --no-save --ignore-scripts $WAAS_WEB_URL $WAAS_VIEM_URL'; node fixWaas.js"
   },
   "dependencies": {
     "@bugsnag/js": "^7.22.4",

--- a/src/wagmiConfig/waasConnector.ts
+++ b/src/wagmiConfig/waasConnector.ts
@@ -1,8 +1,11 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { toViem } from "@coinbase/waas-sdk-viem"
-import type {
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {
   Address,
+  InitializeWaas,
   InitializeWaasOptions,
+  Logout,
   NewWallet,
   ProtocolFamily,
   Waas,
@@ -18,15 +21,6 @@ export class WaasActionFailed extends Error {
     super("Coinbase WaaS action failed")
     this.cause = error
   }
-}
-
-let cwaasModule: typeof import("@coinbase/waas-sdk-web")
-const cwaasImport = async () => {
-  if (cwaasModule) return cwaasModule
-  // eslint-disable-next-line import/no-extraneous-dependencies
-  const mod = await import("@coinbase/waas-sdk-web")
-  cwaasModule = mod
-  return mod
 }
 
 type WalletWithAccount<W extends NewWallet | Wallet> = {
@@ -45,8 +39,6 @@ export default function waasConnector(options: InitializeWaasOptions) {
   let waas: Waas
 
   async function getAllEvmAddresses() {
-    const { ProtocolFamily } = await cwaasImport()
-
     const allAddresses =
       (await waas.wallets.wallet.addresses.all()) as Address<ProtocolFamily>[]
 
@@ -68,8 +60,6 @@ export default function waasConnector(options: InitializeWaasOptions) {
   }
 
   async function withAccount<W extends Wallet>(wallet: W) {
-    const { ProtocolFamily } = await cwaasImport()
-
     const address = await waas.wallets.wallet.addresses.for(ProtocolFamily.EVM)
 
     const account = toViem(address)
@@ -105,8 +95,6 @@ export default function waasConnector(options: InitializeWaasOptions) {
     async getProvider() {
       try {
         if (!waas) {
-          const { InitializeWaas } = await cwaasImport()
-
           waas = await InitializeWaas(options)
         }
 
@@ -155,7 +143,6 @@ export default function waasConnector(options: InitializeWaasOptions) {
       try {
         await this.getProvider()
         throwIfNoWallet()
-        const { ProtocolFamily } = await cwaasImport()
 
         await this.getProvider()
 
@@ -191,7 +178,6 @@ export default function waasConnector(options: InitializeWaasOptions) {
     async createWallet() {
       try {
         await this.getProvider()
-        const { Logout, ProtocolFamily } = await cwaasImport()
 
         await Logout().catch(() => {})
 
@@ -208,7 +194,6 @@ export default function waasConnector(options: InitializeWaasOptions) {
     async restoreWallet(backupData) {
       try {
         await this.getProvider()
-        const { Logout, ProtocolFamily } = await cwaasImport()
 
         await Logout().catch(() => {})
 


### PR DESCRIPTION
- We have quite a few `Failed to load chunk` errors, this PR aims to fix that
- The dynamic import itself was a workaround for this build error:
  - `TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING]: Module ".../node_modules/@coinbase/waas-sdk-web/dist/versions.json" needs an import attribute of type "json"`
- This PR introduces a different workaround, so we can import non-dynamically
  - Adds a `fixWaas.js` script, which replaces the `varsion.json` imports of the relevant files with the correct type assertion


~~Draft until tested on preview~~ Tested it, the build is successful, and functionality is working