### PR TITLE
fix(google login): handle missing permission errors

### DIFF
--- a/src/components/[guild]/JoinModal/hooks/useOauthPopupWindow.ts
+++ b/src/components/[guild]/JoinModal/hooks/useOauthPopupWindow.ts
@@ -122,7 +122,10 @@ const useOauthPopupWindow = <OAuthResponse = { code: string }>(
     const errorDescription = oauthState.error.errorDescription ?? ""
 
     toast({ status: "error", title, description: errorDescription })
-  }, [oauthState.error, toast])
+
+    // toast is left out on purpose, it causes the toast to be shown twice
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [oauthState.error])
 
   return {
     ...oauthState,

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/GoogleLoginButton/hooks/useLoginWithGoogle.ts
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/GoogleLoginButton/hooks/useLoginWithGoogle.ts
@@ -126,7 +126,10 @@ const useLoginWithGoogle = () => {
       const { authData, error } = await googleAuth.onOpen()
 
       if (!authData || !!error) {
-        captureEvent("[WaaS] Google OAuth failed", { error })
+        // Ignore cases, when the user cancels the OAuth
+        if (error?.error !== "access_denied") {
+          captureEvent("[WaaS] Google OAuth failed", { error })
+        }
         return
       }
 

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/GoogleLoginButton/utils/googleDrive.ts
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/GoogleLoginButton/utils/googleDrive.ts
@@ -7,8 +7,18 @@ const DRIVE_FILES_LIST_URL = `https://www.googleapis.com/drive/v3/files?q=${enco
 )}`
 
 export class DriveRequestFailed extends Error {
+  isMissingScope = false
+
   constructor(error: unknown) {
     super("Google Drive request failed")
+
+    this.isMissingScope = (error as any)?.error?.status === "PERMISSION_DENIED"
+
+    if (this.isMissingScope) {
+      this.message =
+        "Missing permissions. Please try again, and make sure to give access to Google Drive"
+    }
+
     this.cause = error
   }
 }


### PR DESCRIPTION
There are 4 changes in this PR:
- The main one is that `DriveRequestFailed` errors can now be flagged with a `isMissingScope` boolean, which indicates if the request failed because the authentication data lacks the Drive scope
- Added a `throw err` at the end of the `.catch` block of `createOrRestoreWallet`. This probably caused false `[WaaS] Wallet successfully initialized` events before, because the `createOrRestoreWallet().catch()` call couldn't reject (:harold:)
  - This one might be the cause of other waas-related error events, since we proceeded without an available wallet in some cases
- `useOauthPopupWindow`: Removed `toast` from the dependency array, as it caused double toasts, like in the other PR
- Excluded manual OAuth cancellations from the `[WaaS] Google OAuth failed` event