### PR TITLE
fix(email allowlist): hide the connect button if access is granted

### DIFF
--- a/src/requirements/Allowlist/AllowlistRequirement.tsx
+++ b/src/requirements/Allowlist/AllowlistRequirement.tsx
@@ -6,7 +6,7 @@ import Requirement, {
 } from "components/[guild]/Requirements/components/Requirement"
 import { useRequirementContext } from "components/[guild]/Requirements/components/RequirementContext"
 import Button from "components/common/Button"
-import useMembership from "components/explorer/hooks/useMembership"
+import { useRoleMembership } from "components/explorer/hooks/useMembership"
 import { ArrowSquareIn, ListPlus } from "phosphor-react"
 import SearchableVirtualListModal from "requirements/common/SearchableVirtualListModal"
 
@@ -30,13 +30,11 @@ const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
 
   const isEmail = requirement.type === "ALLOWLIST_EMAIL"
 
-  const { membership } = useMembership()
+  const { reqAccesses } = useRoleMembership(requirement.roleId)
 
-  const hasAccess = membership?.roles
-    ?.find((role) => role?.roleId === requirement.roleId)
-    ?.requirements?.find(
-      ({ requirementId }) => requirementId === requirement.id
-    )?.access
+  const hasAccess = reqAccesses?.find(
+    ({ requirementId }) => requirementId === requirement.id
+  )?.access
 
   return (
     <Requirement

--- a/src/requirements/Allowlist/AllowlistRequirement.tsx
+++ b/src/requirements/Allowlist/AllowlistRequirement.tsx
@@ -6,6 +6,7 @@ import Requirement, {
 } from "components/[guild]/Requirements/components/Requirement"
 import { useRequirementContext } from "components/[guild]/Requirements/components/RequirementContext"
 import Button from "components/common/Button"
+import useMembership from "components/explorer/hooks/useMembership"
 import { ArrowSquareIn, ListPlus } from "phosphor-react"
 import SearchableVirtualListModal from "requirements/common/SearchableVirtualListModal"
 
@@ -29,13 +30,21 @@ const AllowlistRequirement = ({ ...rest }: RequirementProps): JSX.Element => {
 
   const isEmail = requirement.type === "ALLOWLIST_EMAIL"
 
+  const { membership } = useMembership()
+
+  const hasAccess = membership?.roles
+    ?.find((role) => role?.roleId === requirement.roleId)
+    ?.requirements?.find(
+      ({ requirementId }) => requirementId === requirement.id
+    )?.access
+
   return (
     <Requirement
       image={<Icon as={ListPlus} boxSize={6} />}
       footer={
         isEmail ? (
           <HStack>
-            <RequirementConnectButton />
+            {!hasAccess && <RequirementConnectButton />}
             <HiddenAllowlistText isEmail={isEmail} />
           </HStack>
         ) : (


### PR DESCRIPTION
- Thought about moving this logic inside `RequirementConnectButton`, but I think this is specific to the email allowlist, because it depends on GOOGLE connection as well, not only the EMAIL connection, what do you think?
- [Linear](https://linear.app/guildxyz/issue/GUILD-2756/dont-show-connect-button-on-email-allowlist-requirement-if-user-has)