### PR TITLE
[GUILD-2867] - Discord setup PostHog events

### DIFF
--- a/src/components/[guild]/AddRewardButton/hooks/useAddReward.ts
+++ b/src/components/[guild]/AddRewardButton/hooks/useAddReward.ts
@@ -6,7 +6,13 @@ import useToast from "hooks/useToast"
 import { GuildPlatform, PlatformType } from "types"
 import fetcher from "utils/fetcher"
 
-const useAddReward = ({ onSuccess }: { onSuccess?: () => void }) => {
+const useAddReward = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void
+  onError?: (err: unknown) => void
+}) => {
   const { id, urlName, memberCount, mutateGuild } = useGuild()
 
   const { captureEvent } = usePostHogContext()
@@ -22,6 +28,7 @@ const useAddReward = ({ onSuccess }: { onSuccess?: () => void }) => {
     onError: (error) => {
       showErrorToast(error)
       captureEvent("useAddReward error", { ...postHogOptions, error })
+      onError?.(error)
     },
     onSuccess: (response) => {
       if (response.platformId === PlatformType.CONTRACT_CALL) {

--- a/src/components/common/DiscordGuildSetup/DiscordGuildSetup.tsx
+++ b/src/components/common/DiscordGuildSetup/DiscordGuildSetup.tsx
@@ -52,7 +52,7 @@ const DiscordGuildSetup = ({
       captureEvent("[discord setup] gateables successful")
     },
     onError: () => {
-      captureEvent("[discord setup] gateables failed")
+      captureEvent("[discord setup] gateables failed, showing reconnect alert")
     },
   })
 

--- a/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
@@ -1,4 +1,5 @@
 import { usePrevious } from "@chakra-ui/react"
+import { usePostHogContext } from "components/_app/PostHogProvider"
 import Button from "components/common/Button"
 import CardMotionWrapper from "components/common/CardMotionWrapper"
 import OptionCard from "components/common/OptionCard"
@@ -21,6 +22,7 @@ type Props = {
 }
 
 const DCServerCard = ({ serverData, onSelect, onCancel }: Props): JSX.Element => {
+  const { captureEvent } = usePostHogContext()
   const { onOpen: openAddBotPopup, windowInstance: activeAddBotPopup } =
     usePopupWindow(
       `https://discord.com/api/oauth2/authorize?client_id=${process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID}&guild_id=${serverData.id}&permissions=268782673&scope=bot%20applications.commands`
@@ -73,7 +75,10 @@ const DCServerCard = ({ serverData, onSelect, onCancel }: Props): JSX.Element =>
           <Button
             h={10}
             colorScheme="DISCORD"
-            onClick={openAddBotPopup}
+            onClick={() => {
+              captureEvent("[discord setup] opening add bot modal")
+              openAddBotPopup()
+            }}
             isLoading={!!activeAddBotPopup}
             rightIcon={<ArrowSquareIn />}
           >
@@ -83,7 +88,10 @@ const DCServerCard = ({ serverData, onSelect, onCancel }: Props): JSX.Element =>
           <Button
             h={10}
             colorScheme="green"
-            onClick={() => onSelect(serverData.id)}
+            onClick={() => {
+              captureEvent("[discord setup] selected server")
+              onSelect(serverData.id)
+            }}
             data-test="select-dc-server-button"
           >
             Select

--- a/src/components/common/ReconnectAlert.tsx
+++ b/src/components/common/ReconnectAlert.tsx
@@ -1,12 +1,29 @@
 import { Alert, AlertDescription, AlertIcon, HStack, Text } from "@chakra-ui/react"
 import useConnectPlatform from "components/[guild]/JoinModal/hooks/useConnectPlatform"
+import { usePostHogContext } from "components/_app/PostHogProvider"
 import useGateables from "hooks/useGateables"
 import rewards from "platforms/rewards"
+import { useEffect } from "react"
 import { PlatformName, PlatformType } from "types"
 import Button from "./Button"
 
 const ReconnectAlert = ({ platformName }: { platformName: PlatformName }) => {
   const { mutate } = useGateables(PlatformType[platformName])
+  const { captureEvent } = usePostHogContext()
+
+  useEffect(() => {
+    if (platformName !== "DISCORD") {
+      return
+    }
+
+    captureEvent("[discord setup] reconnect alert is shown")
+
+    return () => {
+      captureEvent("[discord setup] reconnect alert is not shown")
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const {
     onConnect,

--- a/src/components/common/ReconnectAlert.tsx
+++ b/src/components/common/ReconnectAlert.tsx
@@ -1,29 +1,12 @@
 import { Alert, AlertDescription, AlertIcon, HStack, Text } from "@chakra-ui/react"
 import useConnectPlatform from "components/[guild]/JoinModal/hooks/useConnectPlatform"
-import { usePostHogContext } from "components/_app/PostHogProvider"
 import useGateables from "hooks/useGateables"
 import rewards from "platforms/rewards"
-import { useEffect } from "react"
 import { PlatformName, PlatformType } from "types"
 import Button from "./Button"
 
 const ReconnectAlert = ({ platformName }: { platformName: PlatformName }) => {
   const { mutate } = useGateables(PlatformType[platformName])
-  const { captureEvent } = usePostHogContext()
-
-  useEffect(() => {
-    if (platformName !== "DISCORD") {
-      return
-    }
-
-    captureEvent("[discord setup] reconnect alert is shown")
-
-    return () => {
-      captureEvent("[discord setup] reconnect alert is not shown")
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   const {
     onConnect,

--- a/src/components/create-guild/CreateGuildIndex.tsx
+++ b/src/components/create-guild/CreateGuildIndex.tsx
@@ -9,7 +9,7 @@ import MultiPlatformsGrid from "./MultiPlatformGrid"
 const CreateGuildIndex = (): JSX.Element => {
   const { setDisabled } = useCreateGuildContext()
   const [whitoutPlatform, setWhitoutPlatform] = useState(false)
-  const { captureEvent } = usePostHogContext()
+  const { captureEvent, startSessionRecording } = usePostHogContext()
 
   const guildPlatforms = useWatch({ name: "guildPlatforms" })
   const twitter = useWatch({ name: "socialLinks.TWITTER" })
@@ -20,7 +20,17 @@ const CreateGuildIndex = (): JSX.Element => {
 
   return (
     <ClientOnly>
-      <MultiPlatformsGrid onSelection={() => setWhitoutPlatform(false)} />
+      <MultiPlatformsGrid
+        onSelection={(platformName) => {
+          if (platformName === "DISCORD") {
+            captureEvent("[discord setup] started through guild creation")
+
+            // Should we add sampling here? Or is it sampled by default?
+            startSessionRecording()
+          }
+          setWhitoutPlatform(false)
+        }}
+      />
 
       <HStack w="full" justifyContent={"left"} pt={{ base: 4, md: 5 }} spacing={3}>
         <Text fontWeight="semibold" colorScheme="gray">

--- a/src/components/create-guild/MultiPlatformGrid/components/CreateGuildDiscord.tsx
+++ b/src/components/create-guild/MultiPlatformGrid/components/CreateGuildDiscord.tsx
@@ -9,6 +9,7 @@ import {
   ModalOverlay,
   Text,
 } from "@chakra-ui/react"
+import { usePostHogContext } from "components/_app/PostHogProvider"
 import DiscordGuildSetup from "components/common/DiscordGuildSetup"
 import useGateables from "hooks/useGateables"
 import {
@@ -27,6 +28,7 @@ type Props = {
 }
 
 const CreateGuildDiscord = ({ isOpen, onClose }: Props): JSX.Element => {
+  const { captureEvent } = usePostHogContext()
   const { control } = useFormContext<GuildFormType>()
   const { append } = useFieldArray({
     control,
@@ -87,6 +89,8 @@ const CreateGuildDiscord = ({ isOpen, onClose }: Props): JSX.Element => {
             colorScheme="green"
             isDisabled={!selectedServer}
             onClick={() => {
+              captureEvent("[discord setup] server added")
+
               append({
                 platformName: "DISCORD",
                 platformGuildId: discordMethods.getValues("discordServerId"),

--- a/src/components/create-guild/MultiPlatformGrid/components/MultiPlatformSelectButton.tsx
+++ b/src/components/create-guild/MultiPlatformGrid/components/MultiPlatformSelectButton.tsx
@@ -153,6 +153,9 @@ const MultiPlatformSelectButton = ({
                       setValue("socialLinks.TWITTER", "")
                     } else {
                       removePlatform(platform)
+                      if (platform === "DISCORD") {
+                        captureEvent("[discord setup] remove selected server")
+                      }
                       captureEvent("guild creation flow > platform removed", {
                         platform,
                       })

--- a/src/components/create-guild/hooks/useCreateGuild.tsx
+++ b/src/components/create-guild/hooks/useCreateGuild.tsx
@@ -11,7 +11,13 @@ import { Guild, GuildBase, PlatformType } from "types"
 import fetcher from "utils/fetcher"
 import replacer from "utils/guildJsonReplacer"
 
-const useCreateGuild = () => {
+const useCreateGuild = ({
+  onError,
+  onSuccess,
+}: {
+  onError?: (err: unknown) => void
+  onSuccess?: () => void
+} = {}) => {
   const { captureEvent } = usePostHogContext()
 
   const { mutate: mutateYourGuilds } = useYourGuilds()
@@ -26,11 +32,13 @@ const useCreateGuild = () => {
     fetcher("/v2/guilds", signedValidation)
 
   const useSubmitResponse = useSubmitWithSign<Guild>(fetchData, {
-    onError: (error_) =>
+    onError: (error_) => {
       showErrorToast({
         error: processConnectorError(error_.error) ?? error_.error,
         correlationId: error_.correlationId,
-      }),
+      })
+      onError?.(error_)
+    },
     onSuccess: (response_) => {
       triggerConfetti()
 
@@ -56,6 +64,7 @@ const useCreateGuild = () => {
         description: "You're being redirected to its page",
         status: "success",
       })
+      onSuccess?.()
       router.push(`/${response_.urlName}`)
     },
   })


### PR DESCRIPTION
- Added events in the general DC add flow, plus some extra events, which are specific to guild creation, and reward addition to an existing guild
- Session recordings are started when the user initially selects discord in either flow. Not sure if these recordings are sampled by default
- One of the events is fired in a `useEffect` in `NotAdminError`. It seemed like a simple way to do it, but we might want to consider a refactor, let me know what you think
- Some events are duplicated with different names. This is because I'm not sure, which events are used, so didn't want to change the names, but wanted to stick to the same prefix for all the relevant events. But now I'm having second thoughts if it is worth it, so I think we might want to just stick to the existing events
