### PR TITLE
[GUILD-2900] - Fix add bot button

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,5 +1,5 @@
-import { Box, Button as ChakraButton, ButtonProps, Text } from "@chakra-ui/react"
-import { forwardRef, LegacyRef, PropsWithChildren } from "react"
+import { Box, ButtonProps, Button as ChakraButton, Text } from "@chakra-ui/react"
+import { LegacyRef, PropsWithChildren, forwardRef } from "react"
 import { Rest } from "types"
 
 const Button = forwardRef(
@@ -45,7 +45,12 @@ const Button = forwardRef(
       )
 
     return (
-      <ChakraButton ref={ref} isLoading={isLoading} {...rest}>
+      <ChakraButton
+        ref={ref}
+        isLoading={isLoading}
+        loadingText={loadingText}
+        {...rest}
+      >
         {isLoading && loadingText ? (
           <Text
             as="span"

--- a/src/components/common/DiscordGuildSetup/DiscordGuildSetup.tsx
+++ b/src/components/common/DiscordGuildSetup/DiscordGuildSetup.tsx
@@ -47,7 +47,6 @@ const DiscordGuildSetup = ({
     isLoading,
     error: gateablesError,
   } = useGateables(PlatformType.DISCORD, {
-    refreshInterval: 10_000,
     onSuccess: () => {
       captureEvent("[discord setup] gateables successful")
     },

--- a/src/components/common/GitHubGuildSetup.tsx
+++ b/src/components/common/GitHubGuildSetup.tsx
@@ -24,9 +24,7 @@ const GitHubGuildSetup = ({
 }: {
   onSelection?: (platformGuildId: string) => void
 }) => {
-  const { gateables, isLoading, error, mutate } = useGateables(PlatformType.GITHUB, {
-    refreshInterval: 10_000,
-  })
+  const { gateables, isLoading, error, mutate } = useGateables(PlatformType.GITHUB)
 
   /**
    * To have a clean loading state between a reauth and a gatealbes list, it is

--- a/src/components/common/GoogleGuildSetup/GoogleGuildSetup.tsx
+++ b/src/components/common/GoogleGuildSetup/GoogleGuildSetup.tsx
@@ -50,7 +50,6 @@ const GoogleGuildSetup = ({
 
   const { isOpen, onClose, onOpen } = useDisclosure()
   const { gateables, isLoading } = useGateables(PlatformType.GOOGLE, {
-    refreshInterval: 10_000,
     onSuccess: (data, _key, _config) => {
       if (data?.length > gateables?.length) onClose()
     },

--- a/src/hooks/usePopupWindow.ts
+++ b/src/hooks/usePopupWindow.ts
@@ -20,7 +20,8 @@ const defaultWindowFeatures = {
 
 const usePopupWindow = (
   uri?: string,
-  windowFeatures: WindowFeatures = defaultWindowFeatures
+  windowFeatures: WindowFeatures = defaultWindowFeatures,
+  onClose?: () => void
 ) => {
   const [windowInstance, setWindowInstance] = useState<Window>(null)
 
@@ -60,6 +61,7 @@ const usePopupWindow = (
     const timer = setInterval(() => {
       if (windowInstance.closed) {
         setWindowInstance(null)
+        onClose?.()
       }
     }, 1000)
     return () => clearInterval(timer)

--- a/src/hooks/useServerData.ts
+++ b/src/hooks/useServerData.ts
@@ -62,6 +62,7 @@ const useServerData = (
     {
       fallbackData,
       revalidateOnFocus: false,
+      shouldRetryOnError: false,
       ...option?.swrOptions,
     }
   )

--- a/src/hooks/useServerPermissions.ts
+++ b/src/hooks/useServerPermissions.ts
@@ -1,0 +1,45 @@
+import useSWRImmutable from "swr/immutable"
+
+type PermissionEntry = {
+  name:
+    | "Administrator"
+    | "Create Invite"
+    | "Manage Roles"
+    | "Send Messages"
+    | "Embed Links"
+    | "Add Reactions"
+    | "Use External Emoji"
+    | "Read Message History"
+  value: true
+}
+
+type RoleOrderEntry = {
+  roleName: string
+  discordRoleId: string
+  rolePosition: number
+}
+
+type PermissionsResponse = {
+  permissions: PermissionEntry[]
+  roleOrders: RoleOrderEntry[]
+}
+
+export default function useServerPermissions(serverId: string) {
+  const shouldFetch = serverId?.length > 0
+  const { data, error, isLoading, isValidating, mutate } =
+    useSWRImmutable<PermissionsResponse>(
+      shouldFetch ? `/v2/discord/servers/${serverId}/permissions` : null,
+      { shouldRetryOnError: false }
+    )
+
+  const permissions = data?.permissions ? Object.values(data.permissions) : undefined
+
+  return {
+    permissions,
+    rolePrders: data?.roleOrders,
+    error,
+    isLoading,
+    isValidating,
+    mutate,
+  }
+}


### PR DESCRIPTION
- With some experimentation, revalidating the server data with `refreshInterval: 2000` seemed inconsistent, we can't guarantee that revalidation happens, when we want it to
  - Instead, I added an `onClose` callback to `usePopupWindow` which fires when the popup is closed
  - Note that this only works if we have a valid `windowInstance` object. I don't think this is a huge issue, since we used this same object for telling if the popup is open anyway
- Added `shouldRetryOnError: false` to `useServerData`'s SWR call, it seemed unnecessary to revalidate if this request fails
- Also, I've seen that gateables is also revalidated every 10 seconds, not sure why that is needed, the only thing I can think of is to handle if a server is created during the guild creation flow, which I think is an unlikely case 🤔 