### PR TITLE
feat: rework the Collect NFT page

### DIFF
--- a/src/components/[guild]/Requirements/RoleRequirements.tsx
+++ b/src/components/[guild]/Requirements/RoleRequirements.tsx
@@ -15,7 +15,6 @@ import React, {
 } from "react"
 import { VariableSizeList } from "react-window"
 import { Logic, Requirement, Role } from "types"
-import useGuild from "../hooks/useGuild"
 import useRequirements from "../hooks/useRequirements"
 import LogicDivider from "../LogicDivider"
 import { RoleCardCollapseProps } from "../RoleCard"
@@ -40,11 +39,10 @@ const RoleRequirements = ({
   descriptionRef,
   initialRequirementsRef,
 }: Props) => {
-  const guild = useGuild()
-  const { data } = useRequirements(role.id)
+  const { data, isLoading } = useRequirements(role?.id)
 
   const requirements =
-    role.hiddenRequirements || (data?.length === 0 && !(guild as any).isFallback)
+    role.hiddenRequirements || data?.length === 0
       ? [...(data ?? []), { type: "HIDDEN", roleId: role.id } as Requirement]
       : data
 
@@ -72,7 +70,8 @@ const RoleRequirements = ({
       <VStack spacing="0">
         {role.logic === "ANY_OF" && <AnyOfHeader anyOfNum={role.anyOfNum} />}
         <VStack ref={initialRequirementsRef} spacing={0} w="full" p={5} pt={0}>
-          {!requirements?.length ? (
+          {/* Checking !data here too, so we don't show a loading state when we have data from the public request, but the authenticated request is still loading */}
+          {isLoading && !data ? (
             <RoleRequirementsSkeleton />
           ) : isVirtualList ? (
             <VirtualRequirements

--- a/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddContractCallPanel/components/CreateNftForm/hooks/useCreateNft.ts
+++ b/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddContractCallPanel/components/CreateNftForm/hooks/useCreateNft.ts
@@ -1,10 +1,10 @@
-import { NFTDetails } from "components/[guild]/collect/hooks/useNftDetails"
 import useGuild from "components/[guild]/hooks/useGuild"
 import { usePostHogContext } from "components/_app/PostHogProvider"
 import pinFileToIPFS from "hooks/usePinata/utils/pinataUpload"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import useSubmit from "hooks/useSubmit"
 import useToast from "hooks/useToast"
+import { NFTDetailsAPIResponse } from "pages/api/nft/[chain]/[address]"
 import { useState } from "react"
 import guildRewardNFTFacotryAbi from "static/abis/guildRewardNFTFactory"
 import { mutate } from "swr"
@@ -182,7 +182,7 @@ const useCreateNft = (
           title: "Successfully deployed NFT contract",
         })
 
-        const { chain, contractAddress, name, imageUrl } =
+        const { chain, contractAddress, name } =
           response.guildPlatform.platformGuildData
 
         captureEvent("Successfully created NFT", {
@@ -191,16 +191,12 @@ const useCreateNft = (
           contractAddress,
         })
 
-        mutate<NFTDetails>(
+        mutate<NFTDetailsAPIResponse>(
           ["nftDetails", chain, contractAddress],
           {
             creator: address.toLowerCase(),
             name,
-            totalCollectors: 0,
-            totalCollectorsToday: 0,
             standard: "ERC-721", // TODO: we should use a dynamic value here
-            image: imageUrl,
-            description: response.formData.description,
             fee: parseUnits(
               response.formData.price.toString() ?? "0",
               CHAIN_CONFIG[response.formData.chain].nativeCurrency.decimals

--- a/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddContractCallPanel/components/CreateNftForm/hooks/useCreateNft.ts
+++ b/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddContractCallPanel/components/CreateNftForm/hooks/useCreateNft.ts
@@ -197,10 +197,6 @@ const useCreateNft = (
             creator: address.toLowerCase(),
             name,
             standard: "ERC-721", // TODO: we should use a dynamic value here
-            fee: parseUnits(
-              response.formData.price.toString() ?? "0",
-              CHAIN_CONFIG[response.formData.chain].nativeCurrency.decimals
-            ),
           },
           {
             revalidate: false,

--- a/src/components/[guild]/collect/components/RequirementsCard.tsx
+++ b/src/components/[guild]/collect/components/RequirementsCard.tsx
@@ -1,9 +1,10 @@
-import { Box, Stack, useColorModeValue, useDisclosure } from "@chakra-ui/react"
+import { Box, Icon, Stack, useColorModeValue, useDisclosure } from "@chakra-ui/react"
 import RoleRequirements from "components/[guild]/Requirements"
-import { RoleRequirementsSkeleton } from "components/[guild]/Requirements/RoleRequirements"
+import Requirement from "components/[guild]/Requirements/components/Requirement"
 import { RoleRequirementsSectionHeader } from "components/[guild]/RoleCard/components/RoleRequirementsSection"
 import Card from "components/common/Card"
 import CardMotionWrapper from "components/common/CardMotionWrapper"
+import { Question } from "phosphor-react"
 import { PropsWithChildren } from "react"
 import { Role } from "types"
 
@@ -29,9 +30,13 @@ const RequirementsCard = ({ role, children }: PropsWithChildren<Props>) => {
           borderColor={requirementsSectionBorderColor}
         >
           <RoleRequirementsSectionHeader />
+
+          {/* If the role is private, we can't display the requirements */}
           {!role ? (
-            <Box w="full" px={5} pb={5}>
-              <RoleRequirementsSkeleton />
+            <Box w="full" p={5} pt={0}>
+              <Requirement image={<Icon as={Question} boxSize={5} />}>
+                Some secret requirements
+              </Requirement>
             </Box>
           ) : (
             <RoleRequirements

--- a/src/components/[guild]/collect/hooks/useNftDetails.ts
+++ b/src/components/[guild]/collect/hooks/useNftDetails.ts
@@ -90,16 +90,21 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
         functionName: "tokenURI",
         args: [BigInt(1)],
       },
+      {
+        ...contract,
+        functionName: "fee",
+      },
     ],
     query: {
       staleTime: Infinity,
     },
   })
 
-  const [totalSupplyResponse, tokenURIResponse] = data || []
+  const [totalSupplyResponse, tokenURIResponse, feeResponse] = data || []
 
   const totalSupply = totalSupplyResponse?.result
   const tokenURI = tokenURIResponse?.result
+  const fee = feeResponse?.result
 
   const { data: metadata } = useSWRImmutable(
     tokenURI ? ipfsToGuildGateway(tokenURI) : null
@@ -107,7 +112,6 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
 
   return {
     ...nftDetails,
-    fee: nftDetails?.fee ? BigInt(nftDetails.fee) : undefined,
     name: nftDetails?.name ?? guildPlatformData?.name,
     totalCollectors:
       typeof totalSupply === "bigint" ? Number(totalSupply) : undefined,
@@ -117,6 +121,7 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
         : undefined,
     image: ipfsToGuildGateway(metadata?.image) || guildPlatformData?.imageUrl,
     description: metadata?.description as string,
+    fee,
     isLoading:
       isNftDetailsLoading || isFirstTotalSupplyTodayLoadings || isMulticallLoading,
 

--- a/src/components/[guild]/collect/hooks/useNftDetails.ts
+++ b/src/components/[guild]/collect/hooks/useNftDetails.ts
@@ -3,6 +3,7 @@ import guildRewardNftAbi from "static/abis/guildRewardNft"
 import useSWRImmutable from "swr/immutable"
 import { PlatformGuildData, PlatformType } from "types"
 import { getBlockByTime } from "utils/getBlockByTime"
+import ipfsToGuildGateway from "utils/ipfsToGuildGateway"
 import { useReadContract, useReadContracts } from "wagmi"
 import { Chain, Chains } from "wagmiConfig/chains"
 
@@ -133,9 +134,7 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
   const fee = feeResponse?.result
 
   const { data: metadata } = useSWRImmutable(
-    tokenURI
-      ? (tokenURI as string).replace("ipfs://", process.env.NEXT_PUBLIC_IPFS_GATEWAY)
-      : null
+    tokenURI ? ipfsToGuildGateway(tokenURI) : null
   )
 
   return {
@@ -148,9 +147,7 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
         ? Number(totalSupply - firstTotalSupplyToday)
         : undefined,
     standard: isERC1155 ? "ERC-1155" : "ERC-721",
-    image:
-      metadata?.image?.replace("ipfs://", process.env.NEXT_PUBLIC_IPFS_GATEWAY) ||
-      guildPlatformData?.imageUrl,
+    image: ipfsToGuildGateway(metadata?.image) || guildPlatformData?.imageUrl,
     description: metadata?.description as string,
     fee: fee as bigint,
     isLoading: isFirstTotalSupplyTodayLoadings || isMulticallLoading,

--- a/src/components/[guild]/collect/hooks/useNftDetails.ts
+++ b/src/components/[guild]/collect/hooks/useNftDetails.ts
@@ -1,33 +1,20 @@
 import useGuild from "components/[guild]/hooks/useGuild"
+import { NFTDetails } from "pages/api/nft/[chain]/[address]"
 import guildRewardNftAbi from "static/abis/guildRewardNft"
 import useSWRImmutable from "swr/immutable"
 import { PlatformGuildData, PlatformType } from "types"
+import fetcher from "utils/fetcher"
 import { getBlockByTime } from "utils/getBlockByTime"
 import ipfsToGuildGateway from "utils/ipfsToGuildGateway"
 import { useReadContract, useReadContracts } from "wagmi"
 import { Chain, Chains } from "wagmiConfig/chains"
 
-type NftStandard = "ERC-721" | "ERC-1155" | "Unknown"
-
-enum ContractInterface {
-  "ERC721" = "0x80ac58cd",
-  "ERC1155" = "0xd9b67a26",
-}
-
-export type NFTDetails = {
-  creator: string
-  name: string
-  totalCollectors: number
-  totalCollectorsToday?: number
-  standard: NftStandard
-  image?: string
-  description?: string
-  fee: bigint
-}
-
 const currentDate = new Date()
 currentDate.setUTCHours(0, 0, 0, 0)
 const noonUnixTimestamp = currentDate.getTime() / 1000
+
+const fetchNftDetails = ([_, chain, address]) =>
+  fetcher(`/api/nft/${chain}/${address}`)
 
 const useNftDetails = (chain: Chain, address: `0x${string}`) => {
   const { guildPlatforms } = useGuild()
@@ -42,6 +29,15 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
     relevantGuildPlatform?.platformGuildData as PlatformGuildData["CONTRACT_CALL"]
 
   const shouldFetch = Boolean(chain && address)
+
+  const {
+    data: nftDetails,
+    isLoading: isNftDetailsLoading,
+    error: nftDetailsError,
+  } = useSWRImmutable<NFTDetails>(
+    shouldFetch ? ["nftDetails", chain, address] : null,
+    fetchNftDetails
+  )
 
   const { data: firstBlockNumberToday } = useSWRImmutable(
     shouldFetch ? ["firstBlockNumberToday", chain, noonUnixTimestamp] : null,
@@ -87,29 +83,12 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
     contracts: [
       {
         ...contract,
-        functionName: "owner",
-      },
-      {
-        ...contract,
-        functionName: "name",
-      },
-      {
-        ...contract,
         functionName: "totalSupply",
-      },
-      {
-        ...contract,
-        functionName: "supportsInterface",
-        args: [ContractInterface.ERC1155],
       },
       {
         ...contract,
         functionName: "tokenURI",
         args: [BigInt(1)],
-      },
-      {
-        ...contract,
-        functionName: "fee",
       },
     ],
     query: {
@@ -117,42 +96,31 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
     },
   })
 
-  const [
-    ownerResponse,
-    nameResponse,
-    totalSupplyResponse,
-    supportsInterfaceResponse,
-    tokenURIResponse,
-    feeResponse,
-  ] = data || []
+  const [totalSupplyResponse, tokenURIResponse] = data || []
 
-  const owner = ownerResponse?.result
-  const name = nameResponse?.result
   const totalSupply = totalSupplyResponse?.result
-  const isERC1155 = supportsInterfaceResponse?.result
   const tokenURI = tokenURIResponse?.result
-  const fee = feeResponse?.result
 
   const { data: metadata } = useSWRImmutable(
     tokenURI ? ipfsToGuildGateway(tokenURI) : null
   )
 
   return {
-    creator: owner,
-    name: name ?? guildPlatformData?.name,
+    ...nftDetails,
+    fee: nftDetails?.fee ? BigInt(nftDetails.fee) : undefined,
+    name: nftDetails?.name ?? guildPlatformData?.name,
     totalCollectors:
       typeof totalSupply === "bigint" ? Number(totalSupply) : undefined,
     totalCollectorsToday:
       typeof totalSupply === "bigint" && typeof firstTotalSupplyToday === "bigint"
         ? Number(totalSupply - firstTotalSupplyToday)
         : undefined,
-    standard: isERC1155 ? "ERC-1155" : "ERC-721",
     image: ipfsToGuildGateway(metadata?.image) || guildPlatformData?.imageUrl,
     description: metadata?.description as string,
-    fee: fee as bigint,
-    isLoading: isFirstTotalSupplyTodayLoadings || isMulticallLoading,
+    isLoading:
+      isNftDetailsLoading || isFirstTotalSupplyTodayLoadings || isMulticallLoading,
 
-    error: multicallError || error,
+    error: nftDetailsError || multicallError || error,
     refetch,
   }
 }

--- a/src/components/[guild]/collect/hooks/useNftDetails.ts
+++ b/src/components/[guild]/collect/hooks/useNftDetails.ts
@@ -36,6 +36,7 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
       gp.platformGuildData.chain === chain &&
       gp.platformGuildData.contractAddress?.toLowerCase() === address?.toLowerCase()
   )
+
   const guildPlatformData =
     relevantGuildPlatform?.platformGuildData as PlatformGuildData["CONTRACT_CALL"]
 
@@ -59,9 +60,12 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
   } = useReadContract({
     ...contract,
     functionName: "totalSupply",
-    blockNumber: firstBlockNumberToday?.result,
+    blockNumber: firstBlockNumberToday?.result
+      ? BigInt(firstBlockNumberToday.result)
+      : undefined,
     query: {
       enabled: Boolean(firstBlockNumberToday?.result),
+      staleTime: 600_000,
     },
   })
 
@@ -107,6 +111,9 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
         functionName: "fee",
       },
     ],
+    query: {
+      staleTime: Infinity,
+    },
   })
 
   const [
@@ -114,7 +121,7 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
     nameResponse,
     totalSupplyResponse,
     supportsInterfaceResponse,
-    tokenURResponseI,
+    tokenURIResponse,
     feeResponse,
   ] = data || []
 
@@ -122,7 +129,7 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
   const name = nameResponse?.result
   const totalSupply = totalSupplyResponse?.result
   const isERC1155 = supportsInterfaceResponse?.result
-  const tokenURI = tokenURResponseI?.result
+  const tokenURI = tokenURIResponse?.result
   const fee = feeResponse?.result
 
   const { data: metadata } = useSWRImmutable(
@@ -133,7 +140,7 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
 
   return {
     creator: owner,
-    name: name as string,
+    name: name ?? guildPlatformData?.name,
     totalCollectors:
       typeof totalSupply === "bigint" ? Number(totalSupply) : undefined,
     totalCollectorsToday:

--- a/src/components/[guild]/collect/hooks/useNftDetails.ts
+++ b/src/components/[guild]/collect/hooks/useNftDetails.ts
@@ -119,7 +119,7 @@ const useNftDetails = (chain: Chain, address: `0x${string}`) => {
       typeof totalSupply === "bigint" && typeof firstTotalSupplyToday === "bigint"
         ? Number(totalSupply - firstTotalSupplyToday)
         : undefined,
-    image: ipfsToGuildGateway(metadata?.image) || guildPlatformData?.imageUrl,
+    image: ipfsToGuildGateway(metadata?.image),
     description: metadata?.description as string,
     fee,
     isLoading:

--- a/src/hooks/useUsersGuildPins.ts
+++ b/src/hooks/useUsersGuildPins.ts
@@ -8,6 +8,7 @@ import {
   GUILD_PIN_CONTRACTS,
   GuildPinsSupportedChain,
 } from "utils/guildCheckout/constants"
+import ipfsToGuildGateway from "utils/ipfsToGuildGateway"
 import {
   PublicClient,
   createPublicClient,
@@ -122,7 +123,7 @@ const getTokenWithMetadata = (tokenInfo: {
     ...metadata,
     chainId,
     tokenId,
-    image: metadata.image.replace("ipfs://", process.env.NEXT_PUBLIC_IPFS_GATEWAY),
+    image: ipfsToGuildGateway(metadata.image),
   }
 }
 

--- a/src/pages/[guild]/collect/[chain]/[address].tsx
+++ b/src/pages/[guild]/collect/[chain]/[address].tsx
@@ -47,6 +47,7 @@ type Props = {
   guildPlatformId: number
   roleId: number
   rolePlatformId: number
+  fallbackImage?: string
   fallback: { [x: string]: Guild }
 }
 
@@ -61,6 +62,7 @@ const CollectNftPageContent = ({
   address,
   guildPlatformId,
   roleId,
+  fallbackImage,
 }: Omit<Props, "urlName" | "fallback">) => {
   const { theme, guildPlatforms, roles } = useGuild()
   const { isAdmin } = useGuildPermission()
@@ -72,7 +74,12 @@ const CollectNftPageContent = ({
   const nftDescriptionRef = useRef<HTMLDivElement>(null)
   const shouldShowSmallImage = useShouldShowSmallImage(nftDescriptionRef)
 
-  const { name, image, totalCollectors } = useNftDetails(chain, address)
+  const {
+    name,
+    image: imageFromHook,
+    totalCollectors,
+  } = useNftDetails(chain, address)
+  const image = fallbackImage || imageFromHook
 
   return (
     <Layout
@@ -269,6 +276,7 @@ const getStaticProps = async ({ params }) => {
       guildPlatformId: nftGuildReward.id,
       rolePlatformId: nftRoleReward.id,
       roleId: nftRole.id,
+      fallbackImage: nftGuildReward.platformGuildData.imageUrl,
       // Pre-populating the public guild & requirements caches
       fallback: {
         [guildPageEndpoint]: publicGuild,

--- a/src/pages/[guild]/collect/[chain]/[address].tsx
+++ b/src/pages/[guild]/collect/[chain]/[address].tsx
@@ -227,8 +227,7 @@ const getStaticProps = async ({ params }) => {
         }
       ),
     ])
-  } catch (err) {
-    console.log("FETCH GUILD ERROR", err)
+  } catch {
     return {
       notFound: true,
     }
@@ -247,19 +246,16 @@ const getStaticProps = async ({ params }) => {
 
   const nftRole = guild.roles.find((role) => role.id === nftRoleReward?.roleId)
 
-  if (!nftGuildReward || !nftRoleReward || !nftRole) {
-    console.log("REWARD NOT FOUND", nftGuildReward, nftRoleReward, nftRole)
+  if (!nftGuildReward || !nftRoleReward || !nftRole)
     return {
       notFound: true,
     }
-  }
 
   // Calling the serverless endpoint, so if we fetch this data for the first time, it'll be added to the Vercel cache
 
   const baseUrl = process.env.VERCEL_URL
     ? `https://${process.env.VERCEL_URL}`
     : "http://localhost:3000"
-  console.log("nftDetails baseUrl: ", baseUrl)
   const nftDetails = await fetch(`${baseUrl}/api/nft/${chain}/${address}`)
     .then((res) => res.json())
     .catch(() => undefined)

--- a/src/pages/[guild]/collect/[chain]/[address].tsx
+++ b/src/pages/[guild]/collect/[chain]/[address].tsx
@@ -227,7 +227,8 @@ const getStaticProps = async ({ params }) => {
         }
       ),
     ])
-  } catch {
+  } catch (err) {
+    console.log("FETCH GUILD ERROR", err)
     return {
       notFound: true,
     }
@@ -246,16 +247,19 @@ const getStaticProps = async ({ params }) => {
 
   const nftRole = guild.roles.find((role) => role.id === nftRoleReward?.roleId)
 
-  if (!nftGuildReward || !nftRoleReward || !nftRole)
+  if (!nftGuildReward || !nftRoleReward || !nftRole) {
+    console.log("REWARD NOT FOUND", nftGuildReward, nftRoleReward, nftRole)
     return {
       notFound: true,
     }
+  }
 
   // Calling the serverless endpoint, so if we fetch this data for the first time, it'll be added to the Vercel cache
 
   const baseUrl = process.env.VERCEL_URL
     ? `https://${process.env.VERCEL_URL}`
     : "http://localhost:3000"
+  console.log("nftDetails baseUrl: ", baseUrl)
   const nftDetails = await fetch(`${baseUrl}/api/nft/${chain}/${address}`)
     .then((res) => res.json())
     .catch(() => undefined)

--- a/src/pages/[guild]/collect/[chain]/[address].tsx
+++ b/src/pages/[guild]/collect/[chain]/[address].tsx
@@ -1,16 +1,17 @@
 import {
   Box,
   Divider,
-  Heading,
   HStack,
+  Heading,
   SimpleGrid,
   Spacer,
   Stack,
   useBreakpointValue,
 } from "@chakra-ui/react"
-import CollectibleImage from "components/[guild]/collect/components/CollectibleImage"
+import { ThemeProvider } from "components/[guild]/ThemeContext"
 import CollectNft from "components/[guild]/collect/components/CollectNft"
 import { CollectNftProvider } from "components/[guild]/collect/components/CollectNftContext"
+import CollectibleImage from "components/[guild]/collect/components/CollectibleImage"
 import Details from "components/[guild]/collect/components/Details"
 import GuildImageAndName from "components/[guild]/collect/components/GuildImageAndName"
 import Links from "components/[guild]/collect/components/Links"
@@ -23,210 +24,184 @@ import useNftDetails from "components/[guild]/collect/hooks/useNftDetails"
 import useShouldShowSmallImage from "components/[guild]/collect/hooks/useShouldShowSmallImage"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useGuildPermission from "components/[guild]/hooks/useGuildPermission"
-import { ThemeProvider } from "components/[guild]/ThemeContext"
-import { usePostHogContext } from "components/_app/PostHogProvider"
-import ClientOnly from "components/common/ClientOnly"
 import Layout from "components/common/Layout"
 import LinkPreviewHead from "components/common/LinkPreviewHead"
 import { AnimatePresence } from "framer-motion"
-import { GetStaticPaths, GetStaticProps } from "next"
+import { GetStaticPaths } from "next"
 import dynamic from "next/dynamic"
-import { useRouter } from "next/router"
-import ErrorPage from "pages/_error"
 import {
   alchemyApiUrl,
   validateNftAddress,
   validateNftChain,
 } from "pages/api/nft/collectors/[chain]/[address]"
 import { useRef } from "react"
-import { ErrorBoundary } from "react-error-boundary"
 import { SWRConfig } from "swr"
-import { Guild } from "types"
+import { Guild, PlatformType } from "types"
 import fetcher from "utils/fetcher"
 import { Chain } from "wagmiConfig/chains"
 
-const EditNFTDescriptionModalButton = dynamic(
+type Props = {
+  chain: Chain
+  address: `0x${string}`
+  urlName: string
+  guildPlatformId: number
+  roleId: number
+  rolePlatformId: number
+  fallback: { [x: string]: Guild }
+}
+
+const DynamicEditNFTDescriptionModalButton = dynamic(
   () =>
     import("components/[guild]/RoleCard/components/EditNFTDescriptionModalButton"),
   { ssr: false }
 )
 
-type Props = {
-  chain: Chain
-  address: `0x${string}`
-  fallback: { [x: string]: Guild }
-}
-const Page = ({
-  chain: chainFromProps,
-  address: addressFromProps,
-}: Omit<Props, "fallback">) => {
-  const router = useRouter()
-  const { chain: chainFromQuery, address: addressFromQuery } = router.query
-
-  const chain = chainFromProps ?? validateNftChain(chainFromQuery)
-  const address = addressFromProps ?? validateNftAddress(addressFromQuery)
-
-  const { theme, urlName, roles, guildPlatforms } = useGuild()
+const CollectNftPageContent = ({
+  chain,
+  address,
+  guildPlatformId,
+  roleId,
+}: Omit<Props, "urlName" | "fallback">) => {
+  const { theme, guildPlatforms, roles } = useGuild()
   const { isAdmin } = useGuildPermission()
 
-  const guildPlatform = guildPlatforms?.find(
-    (gp) =>
-      gp.platformGuildData?.chain === chain &&
-      gp.platformGuildData?.contractAddress?.toLowerCase() === address
-  )
-
-  const role = roles?.find((r) =>
-    r.rolePlatforms?.find((rp) => rp.guildPlatformId === guildPlatform?.id)
-  )
-  const rolePlatformId = role?.rolePlatforms?.find(
-    (rp) => rp.guildPlatformId === guildPlatform?.id
-  )?.id
+  const guildPlatform = guildPlatforms.find((gp) => gp.id === guildPlatformId)
+  const role = roles.find((r) => r.id === roleId)
 
   const isMobile = useBreakpointValue({ base: true, md: false })
-
   const nftDescriptionRef = useRef<HTMLDivElement>(null)
   const shouldShowSmallImage = useShouldShowSmallImage(nftDescriptionRef)
 
-  const { name, image, totalCollectors, isLoading } = useNftDetails(chain, address)
-
-  const { captureEvent } = usePostHogContext()
-
-  // We probably shouldn't display a 404 here?
-  // if (isDetailed && !guildPlatform) return <ErrorPage statusCode={404} />
+  const { name, image, totalCollectors } = useNftDetails(chain, address)
 
   return (
-    <ErrorBoundary
-      onError={(error, info) => {
-        captureEvent("ErrorBoundary catched error", {
-          page: "[guild]/collect/[chain]/[address]",
-          guild: urlName,
-          nftAddress: address,
-          error,
-          info,
-        })
-      }}
-      fallback={<ErrorPage />}
+    <Layout
+      ogTitle="Collect NFT"
+      background={theme?.color ?? "gray.900"}
+      backgroundImage={theme?.backgroundImage}
+      maxWidth="container.xl"
     >
-      <ClientOnly>
-        <CollectNftProvider
-          roleId={role?.id}
-          rolePlatformId={rolePlatformId}
-          guildPlatform={guildPlatform}
-          chain={chain}
-          nftAddress={address}
+      <Stack spacing={4}>
+        <HStack justifyContent="space-between">
+          <GuildImageAndName />
+          <ShareAndReportButtons
+            isPulseMarkerHidden={totalCollectors > 0}
+            shareButtonLocalStorageKey={`${chain}_${address}_hasClickedShareButton`}
+            shareText={`Check out and collect this awesome ${
+              name ? `${name} ` : " "
+            }NFT on Guild!`}
+          />
+        </HStack>
+
+        <SimpleGrid
+          templateColumns={{
+            base: "1fr",
+            md: "7fr 5fr",
+          }}
+          gap={{ base: 6, lg: 8 }}
         >
-          <Layout
-            ogTitle="Collect NFT"
-            background={theme?.color ?? "gray.900"}
-            backgroundImage={theme?.backgroundImage}
-            maxWidth="container.xl"
-          >
-            <Stack spacing={4}>
-              <HStack justifyContent="space-between">
-                <GuildImageAndName />
-                <ShareAndReportButtons
-                  isPulseMarkerHidden={totalCollectors > 0}
-                  shareButtonLocalStorageKey={`${chain}_${address}_hasClickedShareButton`}
-                  shareText={`Check out and collect this awesome ${
-                    name ? `${name} ` : " "
-                  }NFT on Guild!`}
-                />
-              </HStack>
+          <Stack overflow="hidden" w="full" spacing={{ base: 6, lg: 8 }}>
+            <CollectibleImage src={image} isLoading={!image} />
 
-              <SimpleGrid
-                templateColumns={{
-                  base: "1fr",
-                  md: "7fr 5fr",
-                }}
-                gap={{ base: 6, lg: 8 }}
+            <Stack spacing={6}>
+              <Heading
+                as="h2"
+                fontFamily="display"
+                fontSize={{ base: "3xl", lg: "4xl" }}
               >
-                <Stack overflow="hidden" w="full" spacing={{ base: 6, lg: 8 }}>
-                  <CollectibleImage src={image} isLoading={isLoading} />
+                {name}
+              </Heading>
 
-                  <Stack spacing={6}>
-                    <Heading
-                      as="h2"
-                      fontFamily="display"
-                      fontSize={{ base: "3xl", lg: "4xl" }}
-                    >
-                      {name}
-                    </Heading>
+              {isMobile && (
+                <RequirementsCard role={role}>
+                  <CollectNft />
+                </RequirementsCard>
+              )}
 
-                    {isMobile && (
-                      <RequirementsCard role={role}>
-                        <CollectNft />
-                      </RequirementsCard>
-                    )}
-
-                    <Box ref={nftDescriptionRef} lineHeight={1.75}>
-                      <HStack alignItems="start" justifyContent="flex-end">
-                        <RichTextDescription
-                          text={guildPlatform?.platformGuildData?.description}
-                        />
-                        <Spacer m="0" />
-                        {isAdmin && (
-                          <EditNFTDescriptionModalButton
-                            guildPlatform={guildPlatform}
-                          />
-                        )}
-                      </HStack>
-                    </Box>
-                  </Stack>
-                  <Divider />
-                  <Links />
-                  <Divider />
-                  <Details />
-                  {!!alchemyApiUrl[chain] && (
-                    <>
-                      <Divider />
-                      <TopCollectors />
-                    </>
+              <Box ref={nftDescriptionRef} lineHeight={1.75}>
+                <HStack alignItems="start" justifyContent="flex-end">
+                  <RichTextDescription
+                    text={guildPlatform?.platformGuildData?.description}
+                  />
+                  <Spacer m="0" />
+                  {isAdmin && (
+                    <DynamicEditNFTDescriptionModalButton
+                      guildPlatform={guildPlatform}
+                    />
                   )}
-                </Stack>
-
-                {!isMobile && (
-                  <AnimatePresence>
-                    <Stack
-                      position="sticky"
-                      top={{ base: 4, md: 5 }}
-                      spacing={8}
-                      h="max-content"
-                    >
-                      {shouldShowSmallImage && (
-                        <SmallImageAndRoleName
-                          imageElement={
-                            <CollectibleImage src={image} isLoading={isLoading} />
-                          }
-                          name={name}
-                          role={role}
-                        />
-                      )}
-
-                      <RequirementsCard role={role}>
-                        <CollectNft />
-                      </RequirementsCard>
-                    </Stack>
-                  </AnimatePresence>
-                )}
-              </SimpleGrid>
+                </HStack>
+              </Box>
             </Stack>
-          </Layout>
-        </CollectNftProvider>
-      </ClientOnly>
-    </ErrorBoundary>
+            <Divider />
+            <Links />
+            <Divider />
+            <Details />
+            {!!alchemyApiUrl[chain] && (
+              <>
+                <Divider />
+                <TopCollectors />
+              </>
+            )}
+          </Stack>
+
+          {!isMobile && (
+            <AnimatePresence>
+              <Stack
+                position="sticky"
+                top={{ base: 4, md: 5 }}
+                spacing={8}
+                h="max-content"
+              >
+                {shouldShowSmallImage && (
+                  <SmallImageAndRoleName
+                    imageElement={
+                      <CollectibleImage src={image} isLoading={!image} />
+                    }
+                    name={name}
+                    role={role}
+                  />
+                )}
+
+                <RequirementsCard role={role}>
+                  <CollectNft />
+                </RequirementsCard>
+              </Stack>
+            </AnimatePresence>
+          )}
+        </SimpleGrid>
+      </Stack>
+    </Layout>
   )
 }
 
-const CollectNftPage = ({ fallback, ...rest }: Props) => (
+const CollectNftPageProviderWrapper = (
+  props: Omit<Props, "urlName" | "fallback">
+) => {
+  const { chain, address, guildPlatformId, rolePlatformId, roleId } = props
+  const { guildPlatforms } = useGuild()
+
+  return (
+    <CollectNftProvider
+      guildPlatform={guildPlatforms?.find((gp) => gp.id === guildPlatformId)}
+      roleId={roleId}
+      rolePlatformId={rolePlatformId}
+      chain={chain}
+      nftAddress={address}
+    >
+      <CollectNftPageContent {...props} />
+    </CollectNftProvider>
+  )
+}
+
+const CollectNftPage = ({ fallback, urlName, ...rest }: Props) => (
   <SWRConfig value={fallback && { fallback }}>
-    <LinkPreviewHead path={Object.values(fallback ?? {})[0]?.urlName ?? ""} />
+    <LinkPreviewHead path={urlName} />
     <ThemeProvider>
-      <Page {...rest} />
+      <CollectNftPageProviderWrapper {...rest} />
     </ThemeProvider>
   </SWRConfig>
 )
-
-const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+const getStaticProps = async ({ params }) => {
   const { chain: chainFromQuery, address: addressFromQuery, guild: urlName } = params
   const chain = validateNftChain(chainFromQuery)
   const address = validateNftAddress(addressFromQuery)
@@ -236,22 +211,61 @@ const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
       notFound: true,
     }
 
-  const endpoint = `/v2/guilds/guild-page/${urlName}`
-  const guild: Guild = await fetcher(endpoint).catch((_) => ({}))
+  const guildPageEndpoint = `/v2/guilds/guild-page/${urlName}`
 
-  if (!guild?.id)
+  let publicGuild: Guild, guild: Guild
+  try {
+    ;[publicGuild, guild] = await Promise.all([
+      fetcher(guildPageEndpoint),
+      fetcher(
+        `${process.env.NEXT_PUBLIC_API.replace("/v1", "")}${guildPageEndpoint}`,
+        {
+          headers: {
+            "x-guild-service": "APP",
+            "x-guild-auth": process.env.GUILD_API_KEY,
+          },
+        }
+      ),
+    ])
+  } catch {
+    return {
+      notFound: true,
+    }
+  }
+
+  const nftGuildReward = guild.guildPlatforms.find(
+    (gp) =>
+      gp.platformId === PlatformType.CONTRACT_CALL &&
+      gp.platformGuildData.chain === chain &&
+      gp.platformGuildData.contractAddress.toLowerCase() === address
+  )
+
+  const nftRoleReward = guild.roles
+    .flatMap((role) => role.rolePlatforms)
+    .find((rp) => rp.guildPlatformId === nftGuildReward?.id)
+
+  const nftRole = guild.roles.find((role) => role.id === nftRoleReward?.roleId)
+
+  if (!nftGuildReward || !nftRoleReward || !nftRole)
     return {
       notFound: true,
     }
 
-  guild.isFallback = true
-
+  // TODO: prepopulate the useNftDetails Tanstack Query cache too!
   return {
+    revalidate: 600, // Revalidate at most once every 10 minutes
     props: {
+      urlName: publicGuild.urlName,
       chain,
       address,
+      guildPlatformId: nftGuildReward.id,
+      rolePlatformId: nftRoleReward.id,
+      roleId: nftRole.id,
+      // Pre-populating the public guild & requirements caches
       fallback: {
-        [endpoint]: guild,
+        [guildPageEndpoint]: publicGuild,
+        [`/v2/guilds/${publicGuild.id}/roles/${nftRole.id}/requirements`]:
+          publicGuild.roles.find((r) => r.id === nftRole.id)?.requirements ?? [],
       },
     },
   }

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -87,7 +87,7 @@ const PageWrapper = (props) => (
   </IntercomProvider>
 )
 
-Page.getInitialProps = ({ res, err }) => {
+PageWrapper.getInitialProps = ({ res, err }) => {
   const statusCode = res ? res.statusCode : err ? err.statusCode : 404
   return { statusCode }
 }

--- a/src/pages/api/nft/[chain]/[address].ts
+++ b/src/pages/api/nft/[chain]/[address].ts
@@ -1,0 +1,130 @@
+import { NextApiHandler } from "next"
+import guildRewardNftAbi from "static/abis/guildRewardNft"
+import { OneOf } from "types"
+import { createPublicClient } from "viem"
+import { wagmiConfig } from "wagmiConfig"
+import { Chains } from "wagmiConfig/chains"
+import {
+  validateNftAddress,
+  validateNftChain,
+} from "../collectors/[chain]/[address]"
+
+type NftStandard = "ERC-721" | "ERC-1155" | "Unknown"
+enum ContractInterface {
+  "ERC721" = "0x80ac58cd",
+  "ERC1155" = "0xd9b67a26",
+}
+
+export type NFTDetails = {
+  creator: string
+  name: string
+  totalCollectors: number
+  totalCollectorsToday?: number
+  standard: NftStandard
+  image?: string
+  description?: string
+  fee: bigint
+}
+
+// Only returning data which we can cache infinitely, so we don't need to refetch it if the metadata/totalSupply changes
+export type NFTDetailsAPIResponse<FeeType = bigint> = OneOf<
+  Omit<
+    NFTDetails,
+    "totalCollectors" | "totalCollectorsToday" | "description" | "image" | "fee"
+  > & { fee: FeeType },
+  { error: string }
+>
+
+const handler: NextApiHandler<NFTDetailsAPIResponse<string>> = async (req, res) => {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET")
+    return res.status(405).json({ error: `Method ${req.method} is not allowed` })
+  }
+
+  const { chain: queryChain, address: queryAddress } = req.query
+  const chain = validateNftChain(queryChain)
+  const address = validateNftAddress(queryAddress)
+
+  if (!chain || !address) {
+    res.status(400).json({
+      error: "Invalid query parameters",
+    })
+    return
+  }
+
+  const chainFromConfig = wagmiConfig.chains.find((c) => c.id === Chains[chain])
+
+  if (!chainFromConfig) {
+    res.status(400).json({
+      error: "Unsupported chain",
+    })
+    return
+  }
+
+  const client = createPublicClient({
+    chain: chainFromConfig,
+    transport: wagmiConfig._internal.transports[chainFromConfig.id],
+  })
+
+  const contract = {
+    address,
+    abi: guildRewardNftAbi,
+    chainId: chainFromConfig.id,
+  } as const
+
+  const data = await client.multicall({
+    /**
+     * We need to @ts-ignore this line, since we get a "Type instantiation is
+     * excessively deep and possibly infinite" error here until strictNullChecks is
+     * set to false in our tsconfig. We should set it to true & sort out the related
+     * issues in another PR.
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    contracts: [
+      {
+        ...contract,
+        functionName: "owner",
+      },
+      {
+        ...contract,
+        functionName: "name",
+      },
+      {
+        ...contract,
+        functionName: "supportsInterface",
+        args: [ContractInterface.ERC1155],
+      },
+      {
+        ...contract,
+        functionName: "fee",
+      },
+    ],
+  })
+
+  if (data.some((r) => r.status === "failure")) {
+    res.status(500).json({
+      error: "Couldn't fetch NFT details",
+    })
+    return
+  }
+
+  const [ownerResponse, nameResponse, supportsInterfaceResponse, feeResponse] =
+    data || []
+
+  const creator = ownerResponse?.result
+  const name = nameResponse?.result
+  const isERC1155 = supportsInterfaceResponse?.result
+  const fee = feeResponse?.result
+
+  // Caching for a year, because on-chain data won't change
+  res.setHeader("Cache-Control", "s-maxage=31536000")
+  res.json({
+    creator,
+    name,
+    standard: isERC1155 ? "ERC-1155" : "ERC-721",
+    fee: fee.toString(),
+  })
+}
+
+export default handler

--- a/src/pages/api/nft/collectors/[chain]/[address].ts
+++ b/src/pages/api/nft/collectors/[chain]/[address].ts
@@ -21,7 +21,7 @@ export type TopCollectorsResponse = OneOf<
 
 export const alchemyApiUrl: Record<ContractCallSupportedChain, string> = {
   POLYGON: `https://polygon-mainnet.g.alchemy.com/nft/v3/${process.env.POLYGON_ALCHEMY_KEY}/getOwnersForContract`,
-  POLYGON_MUMBAI: `https://polygon-mumbai.g.alchemy.com/nft/v3/${process.env.POLYGON_MUMBAI_ALCHEMY_KEY}/getOwnersForContract`,
+  POLYGON_MUMBAI: "",
   BASE_MAINNET: `https://base-mainnet.g.alchemy.com/nft/v3/${process.env.BASE_ALCHEMY_KEY}/getOwnersForContract`,
   ETHEREUM: `https://eth-mainnet.g.alchemy.com/nft/v3/${process.env.MAINNET_ALCHEMY_KEY}/getOwnersForContract`,
   OPTIMISM: `https://opt-mainnet.g.alchemy.com/nft/v3/${process.env.OPTIMISM_ALCHEMY_KEY}/getOwnersForContract`,
@@ -29,7 +29,7 @@ export const alchemyApiUrl: Record<ContractCallSupportedChain, string> = {
   CRONOS: "",
   MANTLE: "",
   ZKSYNC_ERA: "",
-  LINEA: ""
+  LINEA: "",
 }
 
 export const validateNftChain = (value: string | string[]): Chain => {
@@ -40,7 +40,7 @@ export const validateNftChain = (value: string | string[]): Chain => {
 export const validateNftAddress = (value: string | string[]): `0x${string}` => {
   const valueAsString = value?.toString()
   if (!ADDRESS_REGEX.test(valueAsString)) return null
-  return valueAsString as `0x${string}`
+  return valueAsString.toLowerCase() as `0x${string}`
 }
 
 const handler: NextApiHandler<TopCollectorsResponse> = async (req, res) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -500,6 +500,7 @@ type Role = SimpleRole & {
   createdAt?: string
   updatedAt?: string
   lastSyncedAt?: string
+  requirements: Requirement[]
 }
 
 type GuildPlatform = {

--- a/src/utils/ipfsToGuildGateway.ts
+++ b/src/utils/ipfsToGuildGateway.ts
@@ -1,0 +1,4 @@
+const ipfsToGuildGateway = (url: string) =>
+  url?.replace("ipfs://", process.env.NEXT_PUBLIC_IPFS_GATEWAY)
+
+export default ipfsToGuildGateway

--- a/src/wagmiConfig/index.ts
+++ b/src/wagmiConfig/index.ts
@@ -131,9 +131,9 @@ export const wagmiConfig = createConfig({
   transports: {
     [mainnet.id]: http(),
     [polygon.id]: http("https://polygon-bor-rpc.publicnode.com"),
-    [polygonMumbai.id]: http(),
+    [polygonMumbai.id]: http("https://polygon-mumbai-bor-rpc.publicnode.com"),
     [polygonZkEvm.id]: http(),
-    [base.id]: http("https://base-rpc.publicnode.com"),
+    [base.id]: http("https://base.llamarpc.com"),
     [baseSepolia.id]: http(),
     [optimism.id]: http(),
     [arbitrum.id]: http(),


### PR DESCRIPTION
This PR aims to fix several problems on the Collect NFT page:

- the biggest change is that we use our own API key during ISR on this page, so we can properly determine if the reward actually doesn't exist (in this case, we can return a 404 response), or it's a hidden/private reward
- added a new serverless endpoint (`/api/nft/[chain]/[address]`): we fetch the immutable onchain data for the NFT on this endpoint, and cache it for a very long time, so we won't need to re-fetch it on the client & we also pre-populate the SWR cache with it during ISR, so we'll be able to load render the page data on client side much faster
- fixed `RoleRequirements`: we only show a skeleton loader when the requirements are actually loading
- fixed the SWR mutation in `useCreateNft`, it probably didn't work at all before (it mutated a non-existent cache key)

**TODO**

- [x] add the `GUILD_API_KEY` env var on Vercel