### PR TITLE
feat(discord setup): permission alert after adding bot

### DIFF
--- a/src/components/common/DiscordGuildSetup/components/PermissionAlert.tsx
+++ b/src/components/common/DiscordGuildSetup/components/PermissionAlert.tsx
@@ -20,7 +20,7 @@ export default function PermissionAlert(props: AlertProps) {
         <Alert status="warning" alignItems={"center"} {...props}>
           <AlertIcon />
           <AlertDescription>
-            Try adding the bot again, and make sure to allow all requested
+            Try adding the bot again, and make sure to grant all requested
             permissions
           </AlertDescription>
         </Alert>

--- a/src/components/common/DiscordGuildSetup/components/PermissionAlert.tsx
+++ b/src/components/common/DiscordGuildSetup/components/PermissionAlert.tsx
@@ -3,7 +3,6 @@ import {
   AlertDescription,
   AlertIcon,
   AlertProps,
-  Box,
   Collapse,
 } from "@chakra-ui/react"
 import { atom, useAtomValue } from "jotai"
@@ -14,17 +13,19 @@ export default function PermissionAlert(props: AlertProps) {
   const shouldShowPermissionAlert = useAtomValue(shouldShowPermissionAlertAtom)
 
   return (
-    // Not sure what the exact reason if, but without a Box wrapper, it had invalid height
-    <Box>
-      <Collapse in={shouldShowPermissionAlert} autoFocus>
-        <Alert status="warning" alignItems={"center"} {...props}>
-          <AlertIcon />
-          <AlertDescription>
-            Try adding the bot again, and make sure to grant all requested
-            permissions
-          </AlertDescription>
-        </Alert>
-      </Collapse>
-    </Box>
+    <Collapse
+      in={shouldShowPermissionAlert}
+      autoFocus
+      style={{
+        flexShrink: 0,
+      }}
+    >
+      <Alert status="warning" alignItems="center" {...props}>
+        <AlertIcon />
+        <AlertDescription>
+          Try adding the bot again, and make sure to grant all requested permissions
+        </AlertDescription>
+      </Alert>
+    </Collapse>
   )
 }

--- a/src/components/common/DiscordGuildSetup/components/PermissionAlert.tsx
+++ b/src/components/common/DiscordGuildSetup/components/PermissionAlert.tsx
@@ -1,0 +1,30 @@
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertProps,
+  Box,
+  Collapse,
+} from "@chakra-ui/react"
+import { atom, useAtomValue } from "jotai"
+
+export const shouldShowPermissionAlertAtom = atom(false)
+
+export default function PermissionAlert(props: AlertProps) {
+  const shouldShowPermissionAlert = useAtomValue(shouldShowPermissionAlertAtom)
+
+  return (
+    // Not sure what the exact reason if, but without a Box wrapper, it had invalid height
+    <Box>
+      <Collapse in={shouldShowPermissionAlert} autoFocus>
+        <Alert status="warning" alignItems={"center"} {...props}>
+          <AlertIcon />
+          <AlertDescription>
+            Try adding the bot again, and make sure to allow all requested
+            permissions
+          </AlertDescription>
+        </Alert>
+      </Collapse>
+    </Box>
+  )
+}

--- a/src/components/create-guild/MultiPlatformGrid/components/CreateGuildDiscord.tsx
+++ b/src/components/create-guild/MultiPlatformGrid/components/CreateGuildDiscord.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Modal,
   ModalBody,
@@ -11,6 +12,7 @@ import {
 } from "@chakra-ui/react"
 import { usePostHogContext } from "components/_app/PostHogProvider"
 import DiscordGuildSetup from "components/common/DiscordGuildSetup"
+import PermissionAlert from "components/common/DiscordGuildSetup/components/PermissionAlert"
 import useGateables from "hooks/useGateables"
 import {
   FormProvider,
@@ -60,29 +62,32 @@ const CreateGuildDiscord = ({ isOpen, onClose }: Props): JSX.Element => {
       <ModalContent>
         <ModalHeader>Connect to Discord</ModalHeader>
         <ModalCloseButton />
-        <ModalBody>
+        <ModalBody display={"flex"} flexDir={"column"}>
           <Text colorScheme="gray" fontWeight="semibold" mb={4}>
             Adding the bot and creating the Guild won't change anything on your
             server
           </Text>
-          <FormProvider {...discordMethods}>
-            <DiscordGuildSetup
-              defaultValues={{
-                name: "",
-                description: "",
-                imageUrl: `/guildLogos/${getRandomInt(286)}.svg`,
-                contacts: [{ type: "EMAIL", contact: "" }],
-                guildPlatforms: [
-                  {
-                    platformName: "DISCORD",
-                    platformGuildId: "",
-                  },
-                ],
-              }}
-              selectedServer={selectedServer}
-              fieldName={`discordServerId`}
-            />
-          </FormProvider>
+          <PermissionAlert mb={4} />
+          <Box overflow={"auto"}>
+            <FormProvider {...discordMethods}>
+              <DiscordGuildSetup
+                defaultValues={{
+                  name: "",
+                  description: "",
+                  imageUrl: `/guildLogos/${getRandomInt(286)}.svg`,
+                  contacts: [{ type: "EMAIL", contact: "" }],
+                  guildPlatforms: [
+                    {
+                      platformName: "DISCORD",
+                      platformGuildId: "",
+                    },
+                  ],
+                }}
+                selectedServer={selectedServer}
+                fieldName={`discordServerId`}
+              />
+            </FormProvider>
+          </Box>
         </ModalBody>
         <ModalFooter>
           <Button

--- a/src/components/create-guild/MultiPlatformGrid/components/CreateGuildDiscord.tsx
+++ b/src/components/create-guild/MultiPlatformGrid/components/CreateGuildDiscord.tsx
@@ -62,13 +62,21 @@ const CreateGuildDiscord = ({ isOpen, onClose }: Props): JSX.Element => {
       <ModalContent>
         <ModalHeader>Connect to Discord</ModalHeader>
         <ModalCloseButton />
-        <ModalBody display={"flex"} flexDir={"column"}>
+        <ModalBody display="flex" flexDir="column">
           <Text colorScheme="gray" fontWeight="semibold" mb={4}>
             Adding the bot and creating the Guild won't change anything on your
             server
           </Text>
           <PermissionAlert mb={4} />
-          <Box overflow={"auto"}>
+          <Box
+            overflow="auto"
+            className="invisible-scrollbar"
+            sx={{
+              maskImage:
+                "linear-gradient(to bottom, transparent 0px, black var(--chakra-sizes-4), black calc(100% - var(--chakra-sizes-4)), transparent)",
+            }}
+            py={4}
+          >
             <FormProvider {...discordMethods}>
               <DiscordGuildSetup
                 defaultValues={{

--- a/src/hooks/useServerPermissions.ts
+++ b/src/hooks/useServerPermissions.ts
@@ -19,7 +19,7 @@ type RoleOrderEntry = {
   rolePosition: number
 }
 
-type PermissionsResponse = {
+export type PermissionsResponse = {
   permissions: PermissionEntry[]
   roleOrders: RoleOrderEntry[]
 }


### PR DESCRIPTION
- Added a `PermissionAlert` component, which appears, when there are missing permissions after a bot is added (this is checked in the `onClose` callback). The `Administrator` permission is ignored from this check, as that is not relevant, and can't be granted through the OAuth page