### PR TITLE
[GUILD-1380] - Sign-in-with-Ethereum

### DIFF
--- a/src/hooks/useSetKeyPair.ts
+++ b/src/hooks/useSetKeyPair.ts
@@ -22,7 +22,7 @@ function getSiweMessage({
   const nonce = `${hash}${nonceRandom}${method ?? 1}`
 
   // Indentation is important inside the string, extra insentation would be extra whitespace in the string
-  return `guild-xyz-git-guild-1380-siwe-zgen.vercel.app wants you to sign in with your Ethereum account:
+  return `guild.xyz wants you to sign in with your Ethereum account:
 ${checksumAddress(addr as `0x${string}`)}
 
 Sign in Guild.xyz

--- a/src/hooks/useSetKeyPair.ts
+++ b/src/hooks/useSetKeyPair.ts
@@ -21,7 +21,7 @@ function getSiweMessage({
 }: MessageParams) {
   const nonce = `${hash}${nonceRandom}${method ?? 1}`
 
-  // Indentation is important inside the string, extra insentation would be extra whitespace in the string
+  // Indentation is important inside the string, extra indentation would be extra whitespace in the string
   return `guild.xyz wants you to sign in with your Ethereum account:
 ${checksumAddress(addr as `0x${string}`)}
 

--- a/src/hooks/useSetKeyPair.ts
+++ b/src/hooks/useSetKeyPair.ts
@@ -7,8 +7,32 @@ import { useEffect } from "react"
 import { mutate } from "swr"
 import { useFetcherWithSign } from "utils/fetcher"
 import { recaptchaAtom, shouldUseReCAPTCHAAtom } from "utils/recaptcha"
+import { checksumAddress } from "viem"
 import useSubmit from "./useSubmit"
-import { SignProps, UseSubmitOptions } from "./useSubmit/useSubmit"
+import { MessageParams, SignProps, UseSubmitOptions } from "./useSubmit/useSubmit"
+
+function getSiweMessage({
+  addr,
+  method,
+  nonce: nonceRandom,
+  ts,
+  chainId,
+  hash,
+}: MessageParams) {
+  const nonce = `${hash}${nonceRandom}${method ?? 1}`
+
+  // Indentation is important inside the string, extra insentation would be extra whitespace in the string
+  return `guild.xyz wants you to sign in with your Ethereum account:
+${checksumAddress(addr as `0x${string}`)}
+
+Sign in Guild.xyz
+
+URI: https://guild.xyz
+Version: 1
+Chain ID: ${chainId ?? 1}
+Nonce: ${nonce}
+Issued At: ${new Date(+ts).toISOString()}`
+}
 
 /**
  * This is a generic RPC internal error code, but we are only using it for testing
@@ -118,8 +142,9 @@ const useSetKeyPair = (submitOptions?: UseSubmitOptions) => {
           body,
           signOptions: {
             forcePrompt: true,
-            msg: "Please sign this message, so we can generate, and assign you a signing key pair. This is needed so you don't have to sign every Guild interaction.",
+            msg: "Sign in Guild.xyz",
             ...signProps,
+            getMessageToSign: getSiweMessage,
           },
         },
       ])

--- a/src/hooks/useSetKeyPair.ts
+++ b/src/hooks/useSetKeyPair.ts
@@ -22,7 +22,7 @@ function getSiweMessage({
   const nonce = `${hash}${nonceRandom}${method ?? 1}`
 
   // Indentation is important inside the string, extra insentation would be extra whitespace in the string
-  return `guild.xyz wants you to sign in with your Ethereum account:
+  return `guild-xyz-git-guild-1380-siwe-zgen.vercel.app wants you to sign in with your Ethereum account:
 ${checksumAddress(addr as `0x${string}`)}
 
 Sign in Guild.xyz

--- a/src/hooks/useSubmit/useSubmit.ts
+++ b/src/hooks/useSubmit/useSubmit.ts
@@ -94,7 +94,7 @@ const signCallbacks = [
   },
 ]
 
-type MessageParams = {
+export type MessageParams = {
   msg: string
   addr: string
   method: ValidationMethod
@@ -259,6 +259,7 @@ type SignBaseProps = {
   keyPair?: CryptoKeyPair
   msg?: string
   ts?: number
+  getMessageToSign?: (params: MessageParams) => string
 }
 
 export type SignProps = SignBaseProps & {
@@ -275,7 +276,7 @@ const createMessageParams = (
   payload: string
 ): MessageParams => ({
   addr: address.toLowerCase(),
-  nonce: randomBytes(32).toString("base64"),
+  nonce: randomBytes(32).toString("hex"),
   ts: ts.toString(),
   hash: payload !== "{}" ? keccak256(stringToBytes(payload)) : undefined,
   method: null,
@@ -365,6 +366,7 @@ export const sign = async ({
   forcePrompt,
   msg = DEFAULT_MESSAGE,
   ts,
+  getMessageToSign = getMessage,
 }: SignProps): Promise<[string, Validation]> => {
   const params = createMessageParams(address, ts ?? Date.now(), msg, payload)
   let sig = null
@@ -395,13 +397,13 @@ export const sign = async ({
     if (walletClient?.account?.type === "local") {
       // For local accounts, such as CWaaS, we request the signature on the account. Otherwise it sends a personal_sign to the rpc
       sig = await walletClient.account.signMessage({
-        message: getMessage(params),
+        message: getMessageToSign(params),
       })
     } else {
       sig = await walletClient
         .signMessage({
           account: address,
-          message: getMessage(params),
+          message: getMessageToSign(params),
         })
         .catch((error) => {
           if (error instanceof UnauthorizedProviderError) {


### PR DESCRIPTION
- Adds an alternative message-generation function `getSiweMessage` which is used when sending a request to the verify endpoint
- More details on the BE PR: https://github.com/guildxyz/guild-backend/pull/1421