### PR TITLE
refactor(AccessHub): `AccessedGuildPlatformCard` component

### DIFF
--- a/src/components/[guild]/AccessHub/AccessHub.tsx
+++ b/src/components/[guild]/AccessHub/AccessHub.tsx
@@ -19,6 +19,7 @@ import PlatformCard from "../RolePlatforms/components/PlatformCard"
 import useGuild from "../hooks/useGuild"
 import useGuildPermission from "../hooks/useGuildPermission"
 import useRoleGroup from "../hooks/useRoleGroup"
+import useUser from "../hooks/useUser"
 import CampaignCards from "./components/CampaignCards"
 import PlatformAccessButton from "./components/PlatformAccessButton"
 import { useAccessedGuildPoints } from "./hooks/useAccessedGuildPoints"
@@ -75,6 +76,7 @@ export const useAccessedGuildPlatforms = (groupId?: number) => {
 }
 
 const AccessHub = (): JSX.Element => {
+  const { id } = useUser()
   const {
     id: guildId,
     featureFlags,
@@ -105,7 +107,7 @@ const AccessHub = (): JSX.Element => {
     (hasVisiblePages && !group)
 
   return (
-    <ClientOnly>
+    <ClientOnly key={id}>
       <Collapse in={showAccessHub} unmountOnExit>
         <SimpleGrid
           templateColumns={{

--- a/src/components/[guild]/AccessHub/AccessHub.tsx
+++ b/src/components/[guild]/AccessHub/AccessHub.tsx
@@ -13,15 +13,12 @@ import useMembership from "components/explorer/hooks/useMembership"
 import dynamic from "next/dynamic"
 import { StarHalf } from "phosphor-react"
 import PointsRewardCard from "platforms/Points/PointsRewardCard"
-import rewards from "platforms/rewards"
-import { PlatformName, PlatformType } from "types"
-import PlatformCard from "../RolePlatforms/components/PlatformCard"
+import { PlatformType } from "types"
 import useGuild from "../hooks/useGuild"
 import useGuildPermission from "../hooks/useGuildPermission"
 import useRoleGroup from "../hooks/useRoleGroup"
-import useUser from "../hooks/useUser"
+import AccessedGuildPlatformCard from "./components/AccessedGuildPlatformCard"
 import CampaignCards from "./components/CampaignCards"
-import PlatformAccessButton from "./components/PlatformAccessButton"
 import { useAccessedGuildPoints } from "./hooks/useAccessedGuildPoints"
 
 const DynamicGuildPinRewardCard = dynamic(
@@ -76,7 +73,6 @@ export const useAccessedGuildPlatforms = (groupId?: number) => {
 }
 
 const AccessHub = (): JSX.Element => {
-  const { id } = useUser()
   const {
     id: guildId,
     featureFlags,
@@ -84,7 +80,6 @@ const AccessHub = (): JSX.Element => {
     groups,
     roles,
     onboardingComplete,
-    isDetailed,
   } = useGuild()
 
   const group = useRoleGroup()
@@ -107,7 +102,7 @@ const AccessHub = (): JSX.Element => {
     (hasVisiblePages && !group)
 
   return (
-    <ClientOnly key={id}>
+    <ClientOnly>
       <Collapse in={showAccessHub} unmountOnExit>
         <SimpleGrid
           templateColumns={{
@@ -120,37 +115,9 @@ const AccessHub = (): JSX.Element => {
           <CampaignCards />
           {guildId === 1985 && shouldShowGuildPin && <DynamicGuildPinRewardCard />}
 
-          {accessedGuildPlatforms?.map((platform) => {
-            if (!rewards[PlatformType[platform.platformId]]) return null
-
-            const {
-              cardPropsHook: useCardProps,
-              cardMenuComponent: PlatformCardMenu,
-              cardWarningComponent: PlatformCardWarning,
-              cardButton: PlatformCardButton,
-            } = rewards[PlatformType[platform.platformId] as PlatformName]
-
-            return (
-              <PlatformCard
-                usePlatformCardProps={useCardProps}
-                guildPlatform={platform}
-                key={platform.id}
-                cornerButton={
-                  isAdmin && isDetailed && PlatformCardMenu ? (
-                    <PlatformCardMenu platformGuildId={platform.platformGuildId} />
-                  ) : PlatformCardWarning ? (
-                    <PlatformCardWarning guildPlatform={platform} />
-                  ) : null
-                }
-              >
-                {PlatformCardButton ? (
-                  <PlatformCardButton platform={platform} />
-                ) : (
-                  <PlatformAccessButton platform={platform} />
-                )}
-              </PlatformCard>
-            )
-          })}
+          {accessedGuildPlatforms?.map((platform) => (
+            <AccessedGuildPlatformCard key={platform.id} platform={platform} />
+          ))}
 
           {accessedGuildPoints?.map((pointPlatform) => (
             <PointsRewardCard key={pointPlatform.id} guildPlatform={pointPlatform} />

--- a/src/components/[guild]/AccessHub/components/AccessedGuildPlatformCard.tsx
+++ b/src/components/[guild]/AccessHub/components/AccessedGuildPlatformCard.tsx
@@ -1,0 +1,41 @@
+import PlatformCard from "components/[guild]/RolePlatforms/components/PlatformCard"
+import useGuild from "components/[guild]/hooks/useGuild"
+import useGuildPermission from "components/[guild]/hooks/useGuildPermission"
+import rewards from "platforms/rewards"
+import { GuildPlatform, PlatformName, PlatformType } from "types"
+import PlatformAccessButton from "./PlatformAccessButton"
+
+const AccessedGuildPlatformCard = ({ platform }: { platform: GuildPlatform }) => {
+  const { isDetailed } = useGuild()
+  const { isAdmin } = useGuildPermission()
+
+  if (!rewards[PlatformType[platform.platformId]]) return null
+
+  const {
+    cardPropsHook: useCardProps,
+    cardMenuComponent: PlatformCardMenu,
+    cardWarningComponent: PlatformCardWarning,
+    cardButton: PlatformCardButton,
+  } = rewards[PlatformType[platform.platformId] as PlatformName]
+
+  return (
+    <PlatformCard
+      usePlatformCardProps={useCardProps}
+      guildPlatform={platform}
+      cornerButton={
+        isAdmin && isDetailed && PlatformCardMenu ? (
+          <PlatformCardMenu platformGuildId={platform.platformGuildId} />
+        ) : PlatformCardWarning ? (
+          <PlatformCardWarning guildPlatform={platform} />
+        ) : null
+      }
+    >
+      {PlatformCardButton ? (
+        <PlatformCardButton platform={platform} />
+      ) : (
+        <PlatformAccessButton platform={platform} />
+      )}
+    </PlatformCard>
+  )
+}
+export default AccessedGuildPlatformCard


### PR DESCRIPTION
When a user switched from an admin account to a non-admin account on a guild's page, they sometimes got a client-side error. The root of the issue is that we essentially created & rendered the card components inside the `AccessHub` component (where we mapped `accessedGuildPlatforms`) - seems this was a bad practice, since we didn't trigger re-renders immediately in some cases, e.g. when a user switched accounts. 

I solved the issue by creating an `AccessedGuildPlatformCard` component and using it inside the access hub.  