### PR TITLE
fix(authenticated pages): don't fallback to 404 unintentionally

### DIFF
--- a/src/components/[guild]/hooks/useGuild.ts
+++ b/src/components/[guild]/hooks/useGuild.ts
@@ -13,12 +13,12 @@ const useGuild = (guildId?: string | number) => {
   const { data, mutate, isLoading, error, isSigned } = useSWRWithOptionalAuth<Guild>(
     id ? `/v2/guilds/guild-page/${id}` : null,
     {
-      onSuccess: (newData) => {
+      onSuccess: (newData: Guild) => {
         // If we fetch guild by id, we populate the urlName cache too and vice versa
 
         if (typeof id === "string") {
           mutateOptionalAuthSWRKey(
-            `/v2/guilds/guild-page/${data.id}`,
+            `/v2/guilds/guild-page/${newData.id}`,
             () => newData,
             {
               revalidate: false,
@@ -28,7 +28,7 @@ const useGuild = (guildId?: string | number) => {
 
         if (typeof id === "number") {
           mutateOptionalAuthSWRKey(
-            `/v2/guilds/guild-page/${data.urlName}`,
+            `/v2/guilds/guild-page/${newData.urlName}`,
             () => newData,
             {
               revalidate: false,

--- a/src/pages/[guild]/analytics.tsx
+++ b/src/pages/[guild]/analytics.tsx
@@ -9,7 +9,7 @@ import Head from "next/head"
 import { useRouter } from "next/router"
 import ErrorPage from "pages/_error"
 
-const GuildPage = (): JSX.Element => {
+const AnalyticsPage = (): JSX.Element => {
   const { textColor, localThemeColor, localBackgroundImage } = useThemeContext()
   const { name, imageUrl } = useGuild()
 
@@ -51,8 +51,8 @@ const GuildPage = (): JSX.Element => {
   )
 }
 
-const GuildPageWrapper = (): JSX.Element => {
-  const { name, error } = useGuild()
+const AnalyticsPageWrapper = (): JSX.Element => {
+  const { error } = useGuild()
   const router = useRouter()
 
   if (error) return <ErrorPage statusCode={404} />
@@ -60,12 +60,12 @@ const GuildPageWrapper = (): JSX.Element => {
   return (
     <>
       <Head>
-        <title>{`${name} analytics`}</title>
-        <meta property="og:title" content={`${name} analytics`} />
+        <title>Analytics</title>
+        <meta property="og:title" content="Analytics" />
       </Head>
-      <ThemeProvider>{router.isReady && <GuildPage />}</ThemeProvider>
+      <ThemeProvider>{router.isReady && <AnalyticsPage />}</ThemeProvider>
     </>
   )
 }
 
-export default GuildPageWrapper
+export default AnalyticsPageWrapper

--- a/src/pages/[guild]/forms/[formId]/responses.tsx
+++ b/src/pages/[guild]/forms/[formId]/responses.tsx
@@ -58,8 +58,8 @@ const FormResponses = (): JSX.Element => {
   )
 }
 
-const GuildPageWrapper = (): JSX.Element => {
-  const { name, error } = useGuild()
+const FormResponsesPageWrapper = (): JSX.Element => {
+  const { error } = useGuild()
   const router = useRouter()
 
   if (error) return <ErrorPage statusCode={404} />
@@ -67,12 +67,12 @@ const GuildPageWrapper = (): JSX.Element => {
   return (
     <>
       <Head>
-        <title>{`${name} members`}</title>
-        <meta property="og:title" content={`${name} members`} />
+        <title>Form responses</title>
+        <meta property="og:title" content="Form responses" />
       </Head>
       <ThemeProvider>{router.isReady && <FormResponses />}</ThemeProvider>
     </>
   )
 }
 
-export default GuildPageWrapper
+export default FormResponsesPageWrapper

--- a/src/pages/[guild]/members.tsx
+++ b/src/pages/[guild]/members.tsx
@@ -124,7 +124,7 @@ const columns = [
   }),
 ]
 
-const GuildPage = (): JSX.Element => {
+const MembersPage = (): JSX.Element => {
   const { textColor, localThemeColor, localBackgroundImage } = useThemeContext()
   const { name, roles, imageUrl } = useGuild()
 
@@ -235,8 +235,8 @@ const GuildPage = (): JSX.Element => {
   )
 }
 
-const GuildPageWrapper = (): JSX.Element => {
-  const { featureFlags, name, error } = useGuild()
+const MembersPageWrapper = (): JSX.Element => {
+  const { featureFlags, error } = useGuild()
   const router = useRouter()
 
   if (error) return <ErrorPage statusCode={404} />
@@ -247,12 +247,12 @@ const GuildPageWrapper = (): JSX.Element => {
   return (
     <>
       <Head>
-        <title>{`${name} members`}</title>
-        <meta property="og:title" content={`${name} members`} />
+        <title>Members</title>
+        <meta property="og:title" content="Members" />
       </Head>
-      <ThemeProvider>{router.isReady && <GuildPage />}</ThemeProvider>
+      <ThemeProvider>{router.isReady && <MembersPage />}</ThemeProvider>
     </>
   )
 }
 
-export default GuildPageWrapper
+export default MembersPageWrapper


### PR DESCRIPTION
- fixed the `useGuild` hook: its `data` was undefined initially when we loaded a client-side only page, so the hook returned an error & we rendered the 404 fallback page
- fixed some `undefined` page titles