### PR TITLE
[GUILD-2901] - `/gateables` call optimization & Discord setup refactor

### DIFF
--- a/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddDiscordPanel.tsx
+++ b/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddDiscordPanel.tsx
@@ -1,45 +1,31 @@
-import { useAddRewardDiscardAlert } from "components/[guild]/AddRewardButton/hooks/useAddRewardDiscardAlert"
 import DiscordGuildSetup from "components/common/DiscordGuildSetup"
 import { AddRewardPanelProps } from "platforms/rewards"
-import { FormProvider, useForm, useWatch } from "react-hook-form"
-import { PlatformType } from "types"
-
-const defaultValues = {
-  platformGuildId: null,
-}
+import { useWatch } from "react-hook-form"
+import { PlatformGuildData, PlatformType } from "types"
 
 const AddDiscordPanel = ({ onAdd }: AddRewardPanelProps) => {
-  const methods = useForm({ mode: "all", defaultValues })
-  useAddRewardDiscardAlert(methods.formState.isDirty)
-
-  const platformGuildId = useWatch({
-    control: methods.control,
-    name: `platformGuildId`,
-  })
-
   // TODO: we could somehow extract this piece of logis from here to make sure that AddDiscordPanel doesn't depend on the role form's state
   const rolePlatforms = useWatch({ name: "rolePlatforms" })
 
   return (
-    <FormProvider {...methods}>
-      <DiscordGuildSetup
-        rolePlatforms={rolePlatforms}
-        fieldName={`platformGuildId`}
-        selectedServer={platformGuildId}
-        defaultValues={defaultValues}
-        onSubmit={() =>
-          onAdd({
-            guildPlatform: {
-              platformName: "DISCORD",
-              platformId: PlatformType.DISCORD,
-              platformGuildId,
-            },
-            isNew: true,
-            platformRoleId: null,
-          })
-        }
-      />
-    </FormProvider>
+    <DiscordGuildSetup
+      rolePlatforms={rolePlatforms}
+      onSubmit={(data) => {
+        onAdd({
+          guildPlatform: {
+            platformName: "DISCORD",
+            platformId: PlatformType.DISCORD,
+            platformGuildId: data?.platformGuildId,
+            platformGuildData: {
+              name: data?.name,
+              imageUrl: data?.img,
+            } as PlatformGuildData["DISCORD"],
+          },
+          isNew: true,
+          platformRoleId: null,
+        })
+      }}
+    />
   )
 }
 

--- a/src/components/common/DiscordGuildSetup/DiscordGuildSetup.tsx
+++ b/src/components/common/DiscordGuildSetup/DiscordGuildSetup.tsx
@@ -1,17 +1,24 @@
 import { GridItem, SimpleGrid } from "@chakra-ui/react"
+import { useAddRewardDiscardAlert } from "components/[guild]/AddRewardButton/hooks/useAddRewardDiscardAlert"
 import useGuild from "components/[guild]/hooks/useGuild"
 import { usePostHogContext } from "components/_app/PostHogProvider"
 import ErrorAlert from "components/common/ErrorAlert"
 import { AnimatePresence } from "framer-motion"
 import useDebouncedState from "hooks/useDebouncedState"
 import useGateables from "hooks/useGateables"
-import { useEffect, useMemo } from "react"
-import { useFormContext } from "react-hook-form"
+import { useEffect, useMemo, useState } from "react"
+import { useForm } from "react-hook-form"
 import { PlatformType } from "types"
 import { OptionSkeletonCard } from "../OptionCard"
 import ReconnectAlert from "../ReconnectAlert"
 import DCServerCard from "./components/DCServerCard"
 import ServerSetupCard from "./components/ServerSetupCard"
+
+const defaultValues = {
+  platformGuildId: null,
+  img: null,
+  name: null,
+}
 
 function NotAdminError() {
   const { captureEvent } = usePostHogContext()
@@ -32,13 +39,17 @@ function NotAdminError() {
 }
 
 const DiscordGuildSetup = ({
-  defaultValues,
-  selectedServer,
-  fieldName,
   rolePlatforms = undefined,
   onSubmit = undefined,
+  shouldHideGotItButton = false,
 }) => {
-  const { reset, setValue } = useFormContext()
+  const { reset, setValue, handleSubmit, formState } = useForm({
+    mode: "all",
+    defaultValues,
+  })
+  useAddRewardDiscardAlert(formState.isDirty)
+
+  const [selectedServer, setSelectedServer] = useState<string>()
 
   const { captureEvent } = usePostHogContext()
 
@@ -70,7 +81,6 @@ const DiscordGuildSetup = ({
 
   const resetForm = () => {
     reset(defaultValues)
-    setValue(fieldName, null)
   }
 
   const guild = useGuild()
@@ -115,11 +125,18 @@ const DiscordGuildSetup = ({
             <DCServerCard
               key={serverData.id}
               serverData={serverData}
-              onSelect={
-                selectedServer
-                  ? undefined
-                  : (newServerId) => setValue(fieldName, newServerId)
-              }
+              onSelect={(newServerId, data) => {
+                setSelectedServer(newServerId)
+
+                setValue("platformGuildId", newServerId, { shouldDirty: true })
+                setValue("name", data?.name, { shouldDirty: true })
+                setValue("img", data?.img, { shouldDirty: true })
+
+                // If the "Got It" button is not shown, the flow ends here, we call onSubmit with the new data
+                if (shouldHideGotItButton) {
+                  handleSubmit(onSubmit)()
+                }
+              }}
               onCancel={
                 selectedServer !== serverData.id ? undefined : () => resetForm()
               }
@@ -128,7 +145,10 @@ const DiscordGuildSetup = ({
       </AnimatePresence>
       {debounceSelectedServer && (
         <GridItem>
-          <ServerSetupCard onSubmit={onSubmit} />
+          <ServerSetupCard
+            // If the "Got It" button is shown, we only call onSubmit when that is pressed
+            onSubmit={!shouldHideGotItButton ? handleSubmit(onSubmit) : undefined}
+          />
         </GridItem>
       )}
     </SimpleGrid>

--- a/src/components/common/DiscordGuildSetup/DiscordGuildSetup.tsx
+++ b/src/components/common/DiscordGuildSetup/DiscordGuildSetup.tsx
@@ -125,12 +125,14 @@ const DiscordGuildSetup = ({
             <DCServerCard
               key={serverData.id}
               serverData={serverData}
-              onSelect={(newServerId, data) => {
-                setSelectedServer(newServerId)
+              onSelect={() => {
+                const { id, name, img } = serverData
 
-                setValue("platformGuildId", newServerId, { shouldDirty: true })
-                setValue("name", data?.name, { shouldDirty: true })
-                setValue("img", data?.img, { shouldDirty: true })
+                setSelectedServer(id)
+
+                setValue("platformGuildId", id, { shouldDirty: true })
+                setValue("name", name, { shouldDirty: true })
+                setValue("img", img, { shouldDirty: true })
 
                 // If the "Got It" button is not shown, the flow ends here, we call onSubmit with the new data
                 if (shouldHideGotItButton) {

--- a/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
@@ -21,7 +21,7 @@ type Props = {
     img: string
     owner: boolean
   }
-  onSelect?: (id: string) => void
+  onSelect?: (id: string, data?: any) => void
   onCancel?: () => void
 }
 
@@ -70,14 +70,14 @@ const DCServerCard = ({ serverData, onSelect, onCancel }: Props): JSX.Element =>
 
   useEffect(() => {
     if (!!prevActiveAddBotPopup && !activeAddBotPopup && hasAllPermissions) {
-      onSelect(serverData.id)
+      onSelect(serverData.id, serverData)
     }
   }, [
     prevActiveAddBotPopup,
     activeAddBotPopup,
     hasAllPermissions,
     onSelect,
-    serverData.id,
+    serverData,
   ])
 
   useEffect(() => {
@@ -129,7 +129,7 @@ const DCServerCard = ({ serverData, onSelect, onCancel }: Props): JSX.Element =>
             colorScheme="green"
             onClick={() => {
               captureEvent("[discord setup] selected server")
-              onSelect(serverData.id)
+              onSelect(serverData.id, serverData)
             }}
             data-test="select-dc-server-button"
           >

--- a/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
@@ -21,7 +21,7 @@ type Props = {
     img: string
     owner: boolean
   }
-  onSelect?: (id: string, data?: any) => void
+  onSelect?: () => void
   onCancel?: () => void
 }
 
@@ -70,7 +70,7 @@ const DCServerCard = ({ serverData, onSelect, onCancel }: Props): JSX.Element =>
 
   useEffect(() => {
     if (!!prevActiveAddBotPopup && !activeAddBotPopup && hasAllPermissions) {
-      onSelect(serverData.id, serverData)
+      onSelect()
     }
   }, [
     prevActiveAddBotPopup,
@@ -129,7 +129,7 @@ const DCServerCard = ({ serverData, onSelect, onCancel }: Props): JSX.Element =>
             colorScheme="green"
             onClick={() => {
               captureEvent("[discord setup] selected server")
-              onSelect(serverData.id, serverData)
+              onSelect()
             }}
             data-test="select-dc-server-button"
           >

--- a/src/components/create-guild/MultiPlatformGrid/components/CreateGuildDiscord.tsx
+++ b/src/components/create-guild/MultiPlatformGrid/components/CreateGuildDiscord.tsx
@@ -13,16 +13,9 @@ import {
 import { usePostHogContext } from "components/_app/PostHogProvider"
 import DiscordGuildSetup from "components/common/DiscordGuildSetup"
 import PermissionAlert from "components/common/DiscordGuildSetup/components/PermissionAlert"
-import useGateables from "hooks/useGateables"
-import {
-  FormProvider,
-  useFieldArray,
-  useForm,
-  useFormContext,
-  useWatch,
-} from "react-hook-form"
+import { useState } from "react"
+import { useFieldArray, useFormContext } from "react-hook-form"
 import { GuildFormType, PlatformGuildData, PlatformType } from "types"
-import getRandomInt from "utils/getRandomInt"
 
 type Props = {
   isOpen: boolean
@@ -36,19 +29,12 @@ const CreateGuildDiscord = ({ isOpen, onClose }: Props): JSX.Element => {
     control,
     name: "guildPlatforms",
   })
-  const discordMethods = useForm({
-    defaultValues: { discordServerId: "", name: "", img: undefined },
-  })
-  const selectedServer = useWatch({
-    control: discordMethods.control,
-    name: `discordServerId`,
-  })
 
-  const discordServers = useGateables(PlatformType.DISCORD)
-
-  const selectedDiscordServerData = discordServers.gateables?.find(
-    (server) => server.id === discordMethods.getValues("discordServerId")
-  )
+  const [selectedServer, setSelectedServer] = useState<{
+    platformGuildId: string
+    img?: string
+    name?: string
+  }>()
 
   return (
     <Modal
@@ -77,40 +63,23 @@ const CreateGuildDiscord = ({ isOpen, onClose }: Props): JSX.Element => {
             }}
             py={4}
           >
-            <FormProvider {...discordMethods}>
-              <DiscordGuildSetup
-                defaultValues={{
-                  name: "",
-                  description: "",
-                  imageUrl: `/guildLogos/${getRandomInt(286)}.svg`,
-                  contacts: [{ type: "EMAIL", contact: "" }],
-                  guildPlatforms: [
-                    {
-                      platformName: "DISCORD",
-                      platformGuildId: "",
-                    },
-                  ],
-                }}
-                selectedServer={selectedServer}
-                fieldName={`discordServerId`}
-              />
-            </FormProvider>
+            <DiscordGuildSetup onSubmit={setSelectedServer} shouldHideGotItButton />
           </Box>
         </ModalBody>
         <ModalFooter>
           <Button
             colorScheme="green"
-            isDisabled={!selectedServer}
+            isDisabled={!selectedServer?.platformGuildId}
             onClick={() => {
               captureEvent("[discord setup] server added")
 
               append({
                 platformName: "DISCORD",
-                platformGuildId: discordMethods.getValues("discordServerId"),
+                platformGuildId: selectedServer?.platformGuildId,
                 platformId: PlatformType.DISCORD,
                 platformGuildData: {
-                  name: selectedDiscordServerData.name,
-                  imageUrl: selectedDiscordServerData.img,
+                  name: selectedServer?.name,
+                  imageUrl: selectedServer?.img,
                 } as PlatformGuildData["DISCORD"],
               })
               onClose()


### PR DESCRIPTION
- Don't call `/gateables` before clicking the Discord card
- Included a small refactor. Some of it is not necessary for the `/gateables` optimization, just seemed reasonable
  - Moved some form state inside `DiscordGuildSetup`
  - The component now works with a fixed form structure instead of getting more params. I think this makes sense, as we use it in 2 places, and the structure is the same for them