### PR TITLE
[GUILD-2755] - Autoconnect email after google connection

### DIFF
--- a/src/components/[guild]/JoinModal/hooks/useConnectPlatform.ts
+++ b/src/components/[guild]/JoinModal/hooks/useConnectPlatform.ts
@@ -122,6 +122,12 @@ const useConnectPlatform = (
                 .then((newPlatformUser) => {
                   mutateUser(
                     async (prev) => {
+                      /**
+                       * For GOOGLE, there is a chance, that the email address got
+                       * linked as EMAIL as well. Therefore if the user doesn't
+                       * already have an EMAIL, we revalidate
+                       */
+
                       const hasEmail = !!prev?.emails?.emailAddress
                       const isGoogleConnection = platformName === "GOOGLE"
 

--- a/src/components/[guild]/JoinModal/hooks/useConnectPlatform.ts
+++ b/src/components/[guild]/JoinModal/hooks/useConnectPlatform.ts
@@ -14,6 +14,7 @@ import { useCallback, useMemo } from "react"
 import useSWR from "swr"
 import { PlatformName, PlatformType } from "types"
 import fetcher, { useFetcherWithSign } from "utils/fetcher"
+import useFetchUserEmail from "./useFetchUserEmail"
 
 type AuthLevel = "membership" | "creation"
 
@@ -74,6 +75,7 @@ const useConnectPlatform = (
 ) => {
   const { id, mutate: mutateUser } = useUser()
   const fetcherWithSign = useFetcherWithSign()
+  const fetchUserEmail = useFetchUserEmail()
   const toast = useToast()
   const showPlatformMergeAlert = useSetAtom(platformMergeAlertAtom)
   const { onOpen } = usePopupWindow()
@@ -117,21 +119,33 @@ const useConnectPlatform = (
                 `/v2/users/${id}/platform-users/${PlatformType[platformName]}`,
                 { method: "GET" },
               ])
-                .then((newPlatformUser) =>
+                .then((newPlatformUser) => {
                   mutateUser(
-                    (prev) => ({
-                      ...prev,
-                      platformUsers: [
-                        ...(prev?.platformUsers ?? []).filter(
-                          ({ platformId }) =>
-                            platformId !== newPlatformUser.platformId
-                        ),
-                        { ...newPlatformUser, platformName },
-                      ],
-                    }),
+                    async (prev) => {
+                      const hasEmail = !!prev?.emails?.emailAddress
+                      const isGoogleConnection = platformName === "GOOGLE"
+
+                      const shouldRefetchEmail = !hasEmail && isGoogleConnection
+
+                      const email = shouldRefetchEmail
+                        ? await fetchUserEmail()
+                        : undefined
+
+                      return {
+                        ...prev,
+                        platformUsers: [
+                          ...(prev?.platformUsers ?? []).filter(
+                            ({ platformId }) =>
+                              platformId !== newPlatformUser.platformId
+                          ),
+                          { ...newPlatformUser, platformName },
+                        ],
+                        emails: email ?? prev?.emails,
+                      }
+                    },
                     { revalidate: false }
                   )
-                )
+                })
                 .then(() => resolve(true))
                 .catch(() => reject("Failed to get new platform connection"))
 

--- a/src/components/[guild]/JoinModal/hooks/useFetchUserEmail.ts
+++ b/src/components/[guild]/JoinModal/hooks/useFetchUserEmail.ts
@@ -1,0 +1,17 @@
+import useUser from "components/[guild]/hooks/useUser"
+import { User } from "types"
+import { useFetcherWithSign } from "utils/fetcher"
+
+export default function useFetchUserEmail() {
+  const { id } = useUser()
+  const fetcherWithSign = useFetcherWithSign()
+
+  return (): Promise<User["emails"]> =>
+    fetcherWithSign([`/v2/users/${id}/emails`, { method: "GET" }])
+      .then(([{ address = null, createdAt = null }] = []) => ({
+        emailAddress: address,
+        pending: false,
+        createdAt,
+      }))
+      .catch(() => null)
+}


### PR DESCRIPTION
- After a GOOGLE platform, if the user doesn't have an EMAIL connection, we revalidate the email data, because the Google account's email might got added to the user as EMAIL as well