### PR TITLE
[GUILD-2708] - Fix Safe wallet connection

### DIFF
--- a/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
+++ b/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
@@ -16,12 +16,15 @@ const useAutoReconnect = () => {
     const recentConnectorId = await config.storage.getItem("recentConnectorId")
     if (!recentConnectorId) return
 
-    let connectorToReconnect = connectors.find(
-      (connector) => connector.id === recentConnectorId
-    )
-    if (!connectorToReconnect) {
-      connectorToReconnect = connectors.find((connector) => connector.id === "safe")
-    }
+    const safeConnector = connectors.find((connector) => connector.id === "safe")
+    const canConnectToSafe = await safeConnector
+      .getProvider()
+      .then((provider) => !!provider)
+      .catch(() => false)
+
+    const connectorToReconnect = canConnectToSafe
+      ? safeConnector
+      : connectors.find((connector) => connector.id === recentConnectorId)
 
     config.setState((prevState) => ({ ...prevState, status: "reconnecting" }))
 

--- a/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
+++ b/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
@@ -31,6 +31,8 @@ const useAutoReconnect = () => {
       ? safeConnector
       : connectors.find((connector) => connector.id === recentConnectorId)
 
+    if (!connectorToReconnect) return
+
     config.setState((prevState) => ({ ...prevState, status: "reconnecting" }))
 
     const provider = await connectorToReconnect.getProvider()

--- a/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
+++ b/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
@@ -17,10 +17,15 @@ const useAutoReconnect = () => {
     if (!recentConnectorId) return
 
     const safeConnector = connectors.find((connector) => connector.id === "safe")
+    console.log("safeConnector", safeConnector)
     const canConnectToSafe = await safeConnector
       .getProvider()
-      .then((provider) => !!provider)
+      .then((provider) => {
+        console.log("Safe provider", provider)
+        return !!provider
+      })
       .catch(() => false)
+    console.log("canConnectToSafe", canConnectToSafe)
 
     const connectorToReconnect = canConnectToSafe
       ? safeConnector

--- a/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
+++ b/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
@@ -16,10 +16,12 @@ const useAutoReconnect = () => {
     const recentConnectorId = await config.storage.getItem("recentConnectorId")
     if (!recentConnectorId) return
 
-    const connectorToReconnect = connectors.find(
+    let connectorToReconnect = connectors.find(
       (connector) => connector.id === recentConnectorId
     )
-    if (!connectorToReconnect) return
+    if (!connectorToReconnect) {
+      connectorToReconnect = connectors.find((connector) => connector.id === "safe")
+    }
 
     config.setState((prevState) => ({ ...prevState, status: "reconnecting" }))
 

--- a/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
+++ b/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
@@ -14,15 +14,10 @@ const useAutoReconnect = () => {
     let connected = false
 
     const safeConnector = connectors.find((connector) => connector.id === "safe")
-    console.log("safeConnector", safeConnector)
     const canConnectToSafe = await safeConnector
       .getProvider()
-      .then((provider) => {
-        console.log("Safe provider", provider)
-        return !!provider
-      })
+      .then((provider) => !!provider)
       .catch(() => false)
-    console.log("canConnectToSafe", canConnectToSafe)
 
     const recentConnectorId = await config.storage.getItem("recentConnectorId")
     if (!recentConnectorId && !canConnectToSafe) return

--- a/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
+++ b/src/components/_app/Web3ConnectionManager/hooks/useAutoReconnect.ts
@@ -13,9 +13,6 @@ const useAutoReconnect = () => {
 
     let connected = false
 
-    const recentConnectorId = await config.storage.getItem("recentConnectorId")
-    if (!recentConnectorId) return
-
     const safeConnector = connectors.find((connector) => connector.id === "safe")
     console.log("safeConnector", safeConnector)
     const canConnectToSafe = await safeConnector
@@ -26,6 +23,9 @@ const useAutoReconnect = () => {
       })
       .catch(() => false)
     console.log("canConnectToSafe", canConnectToSafe)
+
+    const recentConnectorId = await config.storage.getItem("recentConnectorId")
+    if (!recentConnectorId && !canConnectToSafe) return
 
     const connectorToReconnect = canConnectToSafe
       ? safeConnector

--- a/src/hooks/useSubmit/useSubmit.ts
+++ b/src/hooks/useSubmit/useSubmit.ts
@@ -379,7 +379,6 @@ export const sign = async ({
 
     if (walletChainId) {
       if (walletClient.chain.id !== walletChainId) {
-        // TODO If Safe connector, just throw a toast
         await walletClient.switchChain({ id: walletChainId })
       }
       params.chainId = `${walletChainId}`

--- a/src/hooks/useSubmit/useSubmit.ts
+++ b/src/hooks/useSubmit/useSubmit.ts
@@ -378,7 +378,10 @@ export const sign = async ({
       walletChains.length > 0 ? Chains[walletChains[0]] : undefined
 
     if (walletChainId) {
-      await walletClient.switchChain({ id: walletChainId })
+      if (walletClient.chain.id !== walletChainId) {
+        // TODO If Safe connector, just throw a toast
+        await walletClient.switchChain({ id: walletChainId })
+      }
       params.chainId = `${walletChainId}`
     }
 


### PR DESCRIPTION
- Fixes connection to Safe wallet inside a Safe app
- If we are inside a Safe app (checked by `safeConnector.getProvider()`), we try auto-connecting to that
- Additional small fix: only request chain-switching if the `walletClient`'s current `chainId` is different