### PR TITLE
[GUILD-2863] - usePinata optimization

### DIFF
--- a/src/components/[guild]/AccessHub/components/CampaignCards/components/EditCampaignModal.tsx
+++ b/src/components/[guild]/AccessHub/components/CampaignCards/components/EditCampaignModal.tsx
@@ -36,14 +36,10 @@ const EditCampaignModal = ({ groupId, onSuccess, ...modalProps }: Props) => {
       description: description ?? "",
     },
   })
-  const { setValue, handleSubmit } = methods
+  const { handleSubmit } = methods
 
   const iconUploader = usePinata({
-    onSuccess: ({ IpfsHash }) => {
-      setValue("imageUrl", `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`, {
-        shouldTouch: true,
-      })
-    },
+    fieldToSetOnSuccess: "imageUrl",
   })
 
   const { onSubmit, isLoading } = useEditRoleGroup(groupId, onSuccess)

--- a/src/components/[guild]/AddAndOrderRoles/components/AddRoleDrawer.tsx
+++ b/src/components/[guild]/AddAndOrderRoles/components/AddRoleDrawer.tsx
@@ -93,20 +93,8 @@ const AddRoleDrawer = ({ isOpen, onClose, finalFocusRef }): JSX.Element => {
   }
 
   const iconUploader = usePinata({
-    onSuccess: ({ IpfsHash }) => {
-      methods.setValue(
-        "imageUrl",
-        `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`,
-        {
-          shouldTouch: true,
-        }
-      )
-    },
-    onError: () => {
-      methods.setValue("imageUrl", `/guildLogos/${getRandomInt(286)}.svg`, {
-        shouldTouch: true,
-      })
-    },
+    fieldToSetOnSuccess: "imageUrl",
+    fieldToSetOnError: "imageUrl",
   })
 
   const drawerBodyRef = useRef<HTMLDivElement>()

--- a/src/components/[guild]/AddRewardButton/hooks/useSetRoleImageAndNameFromPlatformData.ts
+++ b/src/components/[guild]/AddRewardButton/hooks/useSetRoleImageAndNameFromPlatformData.ts
@@ -15,10 +15,7 @@ const useSetRoleImageAndNameFromPlatformData = (
   const { setValue } = useFormContext()
 
   const { onUpload } = usePinata({
-    onSuccess: ({ IpfsHash }) => {
-      if (IpfsHash)
-        setValue("imageUrl", `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`)
-    },
+    fieldToSetOnSuccess: "imageUrl",
   })
 
   useEffect(() => {

--- a/src/components/[guild]/CreateCampaignModal/CreateCampaignModal.tsx
+++ b/src/components/[guild]/CreateCampaignModal/CreateCampaignModal.tsx
@@ -19,14 +19,10 @@ type Props = { isOpen: boolean; onClose: () => void }
 
 const CreateCampaignModal = (props: Props) => {
   const methods = useForm<CampaignFormType>({ mode: "all" })
-  const { setValue, handleSubmit } = methods
+  const { handleSubmit } = methods
 
   const iconUploader = usePinata({
-    onSuccess: ({ IpfsHash }) => {
-      setValue("imageUrl", `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`, {
-        shouldTouch: true,
-      })
-    },
+    fieldToSetOnSuccess: "imageUrl",
   })
 
   const { onSubmit, isLoading } = useCreateRoleGroup()

--- a/src/components/[guild]/EditGuild/EditGuildDrawer.tsx
+++ b/src/components/[guild]/EditGuild/EditGuildDrawer.tsx
@@ -32,9 +32,9 @@ import useSubmitWithUpload from "hooks/useSubmitWithUpload"
 import useToast from "hooks/useToast"
 import useWarnIfUnsavedChanges from "hooks/useWarnIfUnsavedChanges"
 import dynamic from "next/dynamic"
+import { useCallback } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import { GuildFormType } from "types"
-import getRandomInt from "utils/getRandomInt"
 import handleSubmitDirty from "utils/handleSubmitDirty"
 import useGuildPermission from "../hooks/useGuildPermission"
 import useUser from "../hooks/useUser"
@@ -165,30 +165,17 @@ const EditGuildDrawer = ({
   }
 
   const iconUploader = usePinata({
-    onSuccess: ({ IpfsHash }) => {
-      setValue("imageUrl", `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`, {
-        shouldTouch: true,
-        shouldDirty: true,
-      })
-    },
-    onError: () => {
-      setValue("imageUrl", `/guildLogos/${getRandomInt(286)}.svg`, {
-        shouldTouch: true,
-      })
-    },
+    fieldToSetOnSuccess: "imageUrl",
+    fieldToSetOnError: "imageUrl",
   })
 
+  const onBackgroundUploadError = useCallback(() => {
+    setLocalBackgroundImage(null)
+  }, [setLocalBackgroundImage])
+
   const backgroundUploader = usePinata({
-    onSuccess: ({ IpfsHash }) => {
-      setValue(
-        "theme.backgroundImage",
-        `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`,
-        { shouldDirty: true }
-      )
-    },
-    onError: () => {
-      setLocalBackgroundImage(null)
-    },
+    fieldToSetOnSuccess: "theme.backgroundImage",
+    onError: onBackgroundUploadError,
   })
 
   const { handleSubmit, isUploadingShown, uploadLoadingText } = useSubmitWithUpload(

--- a/src/components/[guild]/Requirements/components/RequirementImageEditor.tsx
+++ b/src/components/[guild]/Requirements/components/RequirementImageEditor.tsx
@@ -3,7 +3,7 @@ import usePinata from "hooks/usePinata"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import useToast from "hooks/useToast"
 import { Upload, X } from "phosphor-react"
-import { PropsWithChildren, useState } from "react"
+import { PropsWithChildren, useCallback, useState } from "react"
 import { useDropzone } from "react-dropzone"
 import { useRequirementContext } from "./RequirementContext"
 
@@ -25,11 +25,17 @@ const RequirementImageEditor = ({
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
 
-  const uploader = usePinata({
-    onSuccess: ({ IpfsHash }) =>
-      onSave(`${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`),
-    onError: () => showErrorToast("Couldn't upload image"),
-  })
+  const onSuccess = useCallback(
+    ({ IpfsHash }) => onSave(`${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`),
+    [onSave]
+  )
+
+  const onError = useCallback(
+    () => showErrorToast("Couldn't upload image"),
+    [showErrorToast]
+  )
+
+  const uploader = usePinata({ onSuccess, onError })
 
   const { getRootProps, getInputProps } = useDropzone({
     multiple: false,

--- a/src/components/[guild]/RoleCard/components/EditRole/EditRole.tsx
+++ b/src/components/[guild]/RoleCard/components/EditRole/EditRole.tsx
@@ -38,7 +38,6 @@ import { ArrowLeft, Check, PencilSimple } from "phosphor-react"
 import { useEffect, useRef } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import { Logic, RolePlatform, Visibility } from "types"
-import getRandomInt from "utils/getRandomInt"
 import handleSubmitDirty from "utils/handleSubmitDirty"
 import DeleteRoleButton from "./components/DeleteRoleButton"
 import RoleGroupSelect from "./components/RoleGroupSelect"
@@ -158,17 +157,8 @@ const EditRole = ({ roleId }: Props): JSX.Element => {
   }
 
   const iconUploader = usePinata({
-    onSuccess: ({ IpfsHash }) => {
-      setValue("imageUrl", `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`, {
-        shouldTouch: true,
-        shouldDirty: true,
-      })
-    },
-    onError: () => {
-      setValue("imageUrl", `/guildLogos/${getRandomInt(286)}.svg`, {
-        shouldTouch: true,
-      })
-    },
+    fieldToSetOnSuccess: "imageUrl",
+    fieldToSetOnError: "imageUrl",
   })
 
   const drawerBodyRef = useRef<HTMLDivElement>()

--- a/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddTokenPanel/components/SetTokenStep.tsx
+++ b/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddTokenPanel/components/SetTokenStep.tsx
@@ -3,7 +3,7 @@ import usePinata from "hooks/usePinata"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import useTokenData from "hooks/useTokenData"
 import { Upload, X } from "phosphor-react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { useDropzone } from "react-dropzone"
 import { useFormContext, useWatch } from "react-hook-form"
 import ChainPicker from "requirements/common/ChainPicker"
@@ -34,10 +34,14 @@ const SetTokenStep = ({ onContinue }: { onContinue: () => void }) => {
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
 
+  const onError = useCallback(
+    () => showErrorToast("Couldn't upload image"),
+    [showErrorToast]
+  )
+
   const uploader = usePinata({
-    onSuccess: ({ IpfsHash }) =>
-      setValue("imageUrl", `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`),
-    onError: () => showErrorToast("Couldn't upload image"),
+    fieldToSetOnSuccess: "imageUrl",
+    onError,
   })
 
   const { getRootProps, getInputProps } = useDropzone({

--- a/src/components/[guild]/crm/FilterByRoles/components/AddHiddenRoleButton.tsx
+++ b/src/components/[guild]/crm/FilterByRoles/components/AddHiddenRoleButton.tsx
@@ -10,12 +10,12 @@ import {
   ModalOverlay,
   useDisclosure,
 } from "@chakra-ui/react"
+import useGuild from "components/[guild]/hooks/useGuild"
 import Button from "components/common/Button"
 import DiscardAlert from "components/common/DiscardAlert"
 import { Modal } from "components/common/Modal"
 import IconSelector from "components/create-guild/IconSelector"
 import Name from "components/create-guild/Name"
-import useGuild from "components/[guild]/hooks/useGuild"
 import usePinata from "hooks/usePinata"
 import useSubmitWithUpload from "hooks/useSubmitWithUpload"
 import { Plus } from "phosphor-react"
@@ -59,20 +59,8 @@ const AddHiddenRoleButton = (buttonProps) => {
   }
 
   const iconUploader = usePinata({
-    onSuccess: ({ IpfsHash }) => {
-      methods.setValue(
-        "imageUrl",
-        `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`,
-        {
-          shouldTouch: true,
-        }
-      )
-    },
-    onError: () => {
-      methods.setValue("imageUrl", `/guildLogos/${getRandomInt(286)}.svg`, {
-        shouldTouch: true,
-      })
-    },
+    fieldToSetOnSuccess: "imageUrl",
+    fieldToSetOnError: "imageUrl",
   })
 
   const onSuccess = () => {

--- a/src/components/create-guild/BasicInfo/BasicInfo.tsx
+++ b/src/components/create-guild/BasicInfo/BasicInfo.tsx
@@ -14,7 +14,7 @@ import { useThemeContext } from "components/[guild]/ThemeContext"
 import Section from "components/common/Section"
 import usePinata from "hooks/usePinata"
 import { useSetAtom } from "jotai"
-import { useEffect } from "react"
+import { useCallback, useEffect } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
 import { GuildFormType } from "types"
 import getRandomInt from "utils/getRandomInt"
@@ -53,17 +53,24 @@ const BasicInfo = (): JSX.Element => {
     return () => setContinueTooltipLabel("")
   }, [setDisabled, name, errors, contacts, errors.contacts, setContinueTooltipLabel])
 
-  const iconUploader = usePinata({
-    onSuccess: ({ IpfsHash }) => {
+  const onIconUploadSuccess = useCallback(
+    ({ IpfsHash }) => {
       setValue("imageUrl", `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`, {
         shouldTouch: true,
       })
     },
-    onError: () => {
-      setValue("imageUrl", `/guildLogos/${getRandomInt(286)}.svg`, {
-        shouldTouch: true,
-      })
-    },
+    [setValue]
+  )
+
+  const onIconUploadError = useCallback(() => {
+    setValue("imageUrl", `/guildLogos/${getRandomInt(286)}.svg`, {
+      shouldTouch: true,
+    })
+  }, [setValue])
+
+  const iconUploader = usePinata({
+    onSuccess: onIconUploadSuccess,
+    onError: onIconUploadError,
   })
 
   const discordPlatformData = guildPlatforms.find(
@@ -85,17 +92,24 @@ const BasicInfo = (): JSX.Element => {
       setValue("urlName", slugify(name), { shouldValidate: true })
   }, [name, dirtyFields, setValue])
 
-  const backgroundUploader = usePinata({
-    onSuccess: ({ IpfsHash }) => {
+  const onBackgrondUploadSuccess = useCallback(
+    ({ IpfsHash }) => {
       setValue(
         "theme.backgroundImage",
         `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`,
         { shouldDirty: true }
       )
     },
-    onError: () => {
-      setLocalBackgroundImage(null)
-    },
+    [setValue]
+  )
+
+  const onBackgrondUploadError = useCallback(() => {
+    setLocalBackgroundImage(null)
+  }, [setLocalBackgroundImage])
+
+  const backgroundUploader = usePinata({
+    onSuccess: onBackgrondUploadSuccess,
+    onError: onBackgrondUploadError,
   })
 
   return (

--- a/src/components/create-guild/BasicInfo/BasicInfo.tsx
+++ b/src/components/create-guild/BasicInfo/BasicInfo.tsx
@@ -17,7 +17,6 @@ import { useSetAtom } from "jotai"
 import { useCallback, useEffect } from "react"
 import { useFormContext, useWatch } from "react-hook-form"
 import { GuildFormType } from "types"
-import getRandomInt from "utils/getRandomInt"
 import slugify from "utils/slugify"
 import { useCreateGuildContext } from "../CreateGuildContext"
 import Description from "../Description"
@@ -53,24 +52,9 @@ const BasicInfo = (): JSX.Element => {
     return () => setContinueTooltipLabel("")
   }, [setDisabled, name, errors, contacts, errors.contacts, setContinueTooltipLabel])
 
-  const onIconUploadSuccess = useCallback(
-    ({ IpfsHash }) => {
-      setValue("imageUrl", `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`, {
-        shouldTouch: true,
-      })
-    },
-    [setValue]
-  )
-
-  const onIconUploadError = useCallback(() => {
-    setValue("imageUrl", `/guildLogos/${getRandomInt(286)}.svg`, {
-      shouldTouch: true,
-    })
-  }, [setValue])
-
   const iconUploader = usePinata({
-    onSuccess: onIconUploadSuccess,
-    onError: onIconUploadError,
+    fieldToSetOnSuccess: "imageUrl",
+    fieldToSetOnError: "imageUrl",
   })
 
   const discordPlatformData = guildPlatforms.find(
@@ -92,23 +76,12 @@ const BasicInfo = (): JSX.Element => {
       setValue("urlName", slugify(name), { shouldValidate: true })
   }, [name, dirtyFields, setValue])
 
-  const onBackgrondUploadSuccess = useCallback(
-    ({ IpfsHash }) => {
-      setValue(
-        "theme.backgroundImage",
-        `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`,
-        { shouldDirty: true }
-      )
-    },
-    [setValue]
-  )
-
   const onBackgrondUploadError = useCallback(() => {
     setLocalBackgroundImage(null)
   }, [setLocalBackgroundImage])
 
   const backgroundUploader = usePinata({
-    onSuccess: onBackgrondUploadSuccess,
+    fieldToSetOnSuccess: "theme.backgroundImage",
     onError: onBackgrondUploadError,
   })
 

--- a/src/hooks/usePinata/usePinata.ts
+++ b/src/hooks/usePinata/usePinata.ts
@@ -20,8 +20,6 @@ export type Uploader = {
   isUploading: boolean
 }
 
-const submit = (ipfsProps: PinToIPFSProps) => pinFileToIPFS(ipfsProps)
-
 const usePinata = ({
   onError,
   onSuccess,
@@ -69,7 +67,7 @@ const usePinata = ({
     [onSuccess, setValue, fieldToSetOnSuccess]
   )
 
-  const { isLoading: isUploading, onSubmit: onUpload } = useSubmit(submit, {
+  const { isLoading: isUploading, onSubmit: onUpload } = useSubmit(pinFileToIPFS, {
     onSuccess: wrappedOnSuccess,
     onError: wrappedOnError,
   })

--- a/src/hooks/usePinata/usePinata.ts
+++ b/src/hooks/usePinata/usePinata.ts
@@ -40,7 +40,7 @@ const usePinata = ({
       })
       onError?.(error)
 
-      if (fieldToSetOnError) {
+      if (fieldToSetOnError && setValue) {
         setValue(fieldToSetOnError, `/guildLogos/${getRandomInt(286)}.svg`, {
           shouldTouch: true,
           shouldDirty: true,

--- a/src/hooks/useSubmit/useSubmit.ts
+++ b/src/hooks/useSubmit/useSubmit.ts
@@ -5,7 +5,7 @@ import { type WalletUnlocked } from "fuels"
 import useLocalStorage from "hooks/useLocalStorage"
 import useTimeInaccuracy from "hooks/useTimeInaccuracy"
 import randomBytes from "randombytes"
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import useSWR from "swr"
 import { ValidationMethod } from "types"
 import {
@@ -46,8 +46,8 @@ const useSubmit = <DataType, ResponseType>(
   const [error, setError] = useState<any>(undefined)
   const [response, setResponse] = useState<ResponseType>(undefined)
 
-  return {
-    onSubmit: (data?: DataType): Promise<ResponseType> => {
+  const onSubmit = useCallback(
+    (data?: DataType): Promise<ResponseType> => {
       setIsLoading(true)
       setError(undefined)
       return fetch(data)
@@ -66,6 +66,11 @@ const useSubmit = <DataType, ResponseType>(
         })
         .finally(() => setIsLoading(false))
     },
+    [allowThrow, fetch, onError, onSuccess]
+  )
+
+  return {
+    onSubmit,
     response,
     isLoading,
     error,

--- a/src/platforms/SecretText/SecretTextDataForm/components/RewardImagePicker.tsx
+++ b/src/platforms/SecretText/SecretTextDataForm/components/RewardImagePicker.tsx
@@ -10,23 +10,16 @@ import Button from "components/common/Button"
 import useDropzone from "hooks/useDropzone"
 import usePinata from "hooks/usePinata"
 import { useState } from "react"
-import { useFormContext, useWatch } from "react-hook-form"
+import { useWatch } from "react-hook-form"
 import Photo from "static/icons/photo.svg"
-import { SecretTextRewardForm } from "../SecretTextDataForm"
 
 const RewardImagePicker = ({ defaultIcon }) => {
-  const { setValue } = useFormContext<SecretTextRewardForm>()
-
   const iconButtonBgColor = useColorModeValue("gray.700", "blackAlpha.300")
   const iconButtonHoverBgColor = useColorModeValue("gray.600", "blackAlpha.200")
   const iconButtonActiveBgColor = useColorModeValue("gray.500", "blackAlpha.100")
   const spinnerBgColor = useColorModeValue("whiteAlpha.700", "blackAlpha.700")
 
-  const { onUpload, isUploading } = usePinata({
-    onSuccess: ({ IpfsHash }) => {
-      setValue("imageUrl", `${process.env.NEXT_PUBLIC_IPFS_GATEWAY}${IpfsHash}`)
-    },
-  })
+  const { onUpload, isUploading } = usePinata({ fieldToSetOnSuccess: "imageUrl" })
 
   const imageUrl = useWatch({ name: "imageUrl" })
 


### PR DESCRIPTION
[Linear](https://linear.app/guildxyz/issue/GUILD-2863/fix-usepinata-hook)

- Tested the changes by adding a `useEffect(() => console.log("onUpdate", onUpdate), [onUpdate])` at the end of `usePinata` before the `return`. Then visiting the `/create-guild` page, and on the `BasicInfo` section, I've made some blur-s on the inputs. The blurs caused both of the `usePinata` hooks to log the message again (plus there were an initial ~8 logs)
- I think the reason is that the form's context changed and that we used anonymous functions without `useCallback`
- Changes in this PR:
  - `useSubmit`: Wrapped the returned `onSubmit` function in a useCallback - [a8dc2a0](https://github.com/guildxyz/guild.xyz/commit/a8dc2a0c4e0e920c6b210b56e40782893a557d34)
  - `usePinata`
    - Moved the submit function out of the hook - [c3a84d2](https://github.com/guildxyz/guild.xyz/commit/c3a84d274cc83f28cddcae56b28faa5fc006fe83)
    - Wrapped the `onSuccess` and `onError` callbacks in `useCallback` calls - [c3a84d2](https://github.com/guildxyz/guild.xyz/commit/c3a84d274cc83f28cddcae56b28faa5fc006fe83)
    - **Refactor**: Added `fieldToSetOnSuccess` and `fieldToSetOnError` props. If set, the hook will perform the `setValue` calls on success/error. This seemed like a good idea, because in most cases, we would just pass callbacks to set a form field, and this way we can avoid having to wrap all those callbacks in `useCallback`s - [778e9bc](https://github.com/guildxyz/guild.xyz/commit/778e9bc8bfc6cd405bf08a93e92c32c73a1602b2)
  - Made the `usePinata` call changes in the places, where the hook is used
    - `BasicInfo`: [778e9bc](https://github.com/guildxyz/guild.xyz/commit/778e9bc8bfc6cd405bf08a93e92c32c73a1602b2)
    - Rest: [f399e09](https://github.com/guildxyz/guild.xyz/commit/f399e0961885b0b17ba5de085c2d6d3563a0715d)