### PR TITLE
fix: indicate required form fields by asterisk

### DIFF
--- a/src/components/[guild]/EditGuild/components/UrlName.tsx
+++ b/src/components/[guild]/EditGuild/components/UrlName.tsx
@@ -23,7 +23,7 @@ const UrlName = ({ maxWidth = "sm" }) => {
   const { urlName: currentUrlName } = useGuild()
 
   return (
-    <FormControl isInvalid={!!errors?.urlName}>
+    <FormControl isInvalid={!!errors?.urlName} isRequired>
       <FormLabel>URL name</FormLabel>
       <InputGroup size="lg" maxWidth={maxWidth}>
         <InputLeftAddon>guild.xyz/</InputLeftAddon>

--- a/src/components/create-guild/BasicInfo/BasicInfo.tsx
+++ b/src/components/create-guild/BasicInfo/BasicInfo.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  FormControl,
   FormLabel,
   HStack,
   SimpleGrid,
@@ -107,11 +108,13 @@ const BasicInfo = (): JSX.Element => {
           templateColumns={{ base: "1fr", md: "1fr 1fr" }}
         >
           <Box flex="1">
-            <FormLabel>Logo and name</FormLabel>
-            <HStack alignItems="start">
-              <IconSelector uploader={iconUploader} minW={512} minH={512} />
-              <Name width={null} />
-            </HStack>
+            <FormControl isRequired>
+              <FormLabel>Logo and name</FormLabel>
+              <HStack alignItems="start">
+                <IconSelector uploader={iconUploader} minW={512} minH={512} />
+                <Name width={null} />
+              </HStack>
+            </FormControl>
           </Box>
           <UrlName maxWidth="unset" />
         </SimpleGrid>


### PR DESCRIPTION
Add `FormControl` and `isRequired` to fields that are missed out.