### PR TITLE
[GUILD-3003] - Reward-related posthog events

### DIFF
--- a/src/components/[guild]/AddRewardButton/hooks/useAddReward.ts
+++ b/src/components/[guild]/AddRewardButton/hooks/useAddReward.ts
@@ -31,6 +31,11 @@ const useAddReward = ({
       onError?.(error)
     },
     onSuccess: (response) => {
+      captureEvent("reward created", {
+        platformName: response.platformName ?? PlatformType[response.platformId],
+        guild: urlName,
+      })
+
       if (response.platformId === PlatformType.CONTRACT_CALL) {
         captureEvent("Created NFT reward", {
           ...postHogOptions,

--- a/src/components/[guild]/AddRewardButton/hooks/useAddReward.ts
+++ b/src/components/[guild]/AddRewardButton/hooks/useAddReward.ts
@@ -33,7 +33,7 @@ const useAddReward = ({
       onError?.(error)
     },
     onSuccess: (response) => {
-      rewardCreated(response.platformId, urlName)
+      rewardCreated(response.platformId)
 
       if (response.platformId === PlatformType.CONTRACT_CALL) {
         captureEvent("Created NFT reward", {

--- a/src/components/[guild]/AddRewardButton/hooks/useAddReward.ts
+++ b/src/components/[guild]/AddRewardButton/hooks/useAddReward.ts
@@ -1,5 +1,6 @@
 import useGuild from "components/[guild]/hooks/useGuild"
 import { usePostHogContext } from "components/_app/PostHogProvider"
+import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import { SignedValidation, useSubmitWithSign } from "hooks/useSubmit"
 import useToast from "hooks/useToast"
@@ -16,6 +17,7 @@ const useAddReward = ({
   const { id, urlName, memberCount, mutateGuild } = useGuild()
 
   const { captureEvent } = usePostHogContext()
+  const { rewardCreated } = useCustomPosthogEvents()
   const postHogOptions = { guild: urlName, memberCount }
 
   const showErrorToast = useShowErrorToast()
@@ -31,10 +33,7 @@ const useAddReward = ({
       onError?.(error)
     },
     onSuccess: (response) => {
-      captureEvent("reward created", {
-        platformName: response.platformName ?? PlatformType[response.platformId],
-        guild: urlName,
-      })
+      rewardCreated(response.platformId, urlName)
 
       if (response.platformId === PlatformType.CONTRACT_CALL) {
         captureEvent("Created NFT reward", {

--- a/src/components/[guild]/JoinModal/hooks/useMembershipUpdate.tsx
+++ b/src/components/[guild]/JoinModal/hooks/useMembershipUpdate.tsx
@@ -91,7 +91,7 @@ const useMembershipUpdate = ({
           correlationId: res.correlationId,
         })
 
-      if (res?.updateMembershipResult?.newMembershipRoleIds?.[0]) {
+      if (res?.updateMembershipResult?.newMembershipRoleIds?.length > 0) {
         const grantedGuildPlatforms = getGuildPlatformsOfRoles(
           res.updateMembershipResult.newMembershipRoleIds,
           guild

--- a/src/components/[guild]/JoinModal/hooks/useMembershipUpdate.tsx
+++ b/src/components/[guild]/JoinModal/hooks/useMembershipUpdate.tsx
@@ -92,22 +92,20 @@ const useMembershipUpdate = ({
         })
 
       if (res?.updateMembershipResult?.newMembershipRoleIds?.[0]) {
-        try {
-          const grantedGuildPlatforms = getGuildPlatformsOfRoles(
-            res.updateMembershipResult.newMembershipRoleIds,
-            guild
-          )
+        const grantedGuildPlatforms = getGuildPlatformsOfRoles(
+          res.updateMembershipResult.newMembershipRoleIds,
+          guild
+        )
 
-          const newGuildPlatforms = grantedGuildPlatforms.filter(
-            ({ id }) => !accessedGuildPlatformIds.has(id)
-          )
+        const newGuildPlatforms = grantedGuildPlatforms.filter(
+          ({ id }) => !accessedGuildPlatformIds.has(id)
+        )
 
-          if (newGuildPlatforms.length > 0) {
-            newGuildPlatforms.forEach((newGuildPlatform) => {
-              rewardGranted(newGuildPlatform.platformId)
-            })
-          }
-        } catch {}
+        if (newGuildPlatforms.length > 0) {
+          newGuildPlatforms.forEach((newGuildPlatform) => {
+            rewardGranted(newGuildPlatform.platformId)
+          })
+        }
       }
 
       if (res?.roleAccesses?.some((role) => !!role.access)) {

--- a/src/components/[guild]/JoinModal/utils/getGuildPlatformsOfRoles.ts
+++ b/src/components/[guild]/JoinModal/utils/getGuildPlatformsOfRoles.ts
@@ -1,0 +1,26 @@
+import useGuild from "components/[guild]/hooks/useGuild"
+
+export default function getGuildPlatformsOfRoles(
+  roleIds: number[],
+  guild: ReturnType<typeof useGuild>
+) {
+  try {
+    const roleIdsSet = new Set(roleIds)
+
+    const rolePlatforms = guild.roles
+      .filter((role) => roleIdsSet.has(role.id))
+      .flatMap((role) => role.rolePlatforms)
+
+    const guildPlatformIds = new Set(
+      rolePlatforms.map(({ guildPlatformId }) => guildPlatformId)
+    )
+
+    const guildPlatforms = guild.guildPlatforms.filter((guildPlatform) =>
+      guildPlatformIds.has(guildPlatform.id)
+    )
+
+    return guildPlatforms
+  } catch {
+    return []
+  }
+}

--- a/src/components/[guild]/RoleCard/components/EditRole/hooks/useEditRole.ts
+++ b/src/components/[guild]/RoleCard/components/EditRole/hooks/useEditRole.ts
@@ -79,7 +79,7 @@ const useEditRole = (roleId: number, onSuccess?: () => void) => {
     onSuccess: (result) => {
       const { updatedRole, updatedRolePlatforms, createdRolePlatforms } = result
 
-      if (createdRolePlatforms?.[0]) {
+      if (createdRolePlatforms?.length > 0) {
         createdRolePlatforms.forEach((rolePlatform) => {
           if (rolePlatform?.createdGuildPlatform) {
             rewardCreated(rolePlatform.createdGuildPlatform.platformId)

--- a/src/components/[guild]/RoleCard/components/EditRole/hooks/useEditRole.ts
+++ b/src/components/[guild]/RoleCard/components/EditRole/hooks/useEditRole.ts
@@ -1,9 +1,9 @@
 import useMembershipUpdate from "components/[guild]/JoinModal/hooks/useMembershipUpdate"
 import useGuild from "components/[guild]/hooks/useGuild"
-import { usePostHogContext } from "components/_app/PostHogProvider"
+import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import useSubmit from "hooks/useSubmit/useSubmit"
-import { OneOf, PlatformType } from "types"
+import { OneOf } from "types"
 import { useFetcherWithSign } from "utils/fetcher"
 import replacer from "utils/guildJsonReplacer"
 import { RoleEditFormData } from "../EditRole"
@@ -18,7 +18,7 @@ const useEditRole = (roleId: number, onSuccess?: () => void) => {
   const errorToast = useShowErrorToast()
   const showErrorToast = useShowErrorToast()
   const fetcherWithSign = useFetcherWithSign()
-  const { captureEvent } = usePostHogContext()
+  const { rewardCreated } = useCustomPosthogEvents()
 
   const submit = async (data: RoleEditFormData) => {
     const {
@@ -82,12 +82,7 @@ const useEditRole = (roleId: number, onSuccess?: () => void) => {
       if (createdRolePlatforms?.[0]) {
         createdRolePlatforms.forEach((rolePlatform) => {
           if (rolePlatform?.createdGuildPlatform) {
-            captureEvent("reward created", {
-              platformName:
-                rolePlatform?.createdGuildPlatform?.platformName ??
-                PlatformType[rolePlatform?.createdGuildPlatform.platformId],
-              guild: urlName,
-            })
+            rewardCreated(rolePlatform.createdGuildPlatform.platformId, urlName)
           }
         })
       }

--- a/src/components/[guild]/RoleCard/components/EditRole/hooks/useEditRole.ts
+++ b/src/components/[guild]/RoleCard/components/EditRole/hooks/useEditRole.ts
@@ -12,7 +12,7 @@ const mapToObject = <T extends { id: number }>(array: T[], by: keyof T = "id") =
   Object.fromEntries(array.map((item) => [item[by], item]))
 
 const useEditRole = (roleId: number, onSuccess?: () => void) => {
-  const { id, mutateGuild, urlName } = useGuild()
+  const { id, mutateGuild } = useGuild()
   const { triggerMembershipUpdate } = useMembershipUpdate()
 
   const errorToast = useShowErrorToast()
@@ -82,7 +82,7 @@ const useEditRole = (roleId: number, onSuccess?: () => void) => {
       if (createdRolePlatforms?.[0]) {
         createdRolePlatforms.forEach((rolePlatform) => {
           if (rolePlatform?.createdGuildPlatform) {
-            rewardCreated(rolePlatform.createdGuildPlatform.platformId, urlName)
+            rewardCreated(rolePlatform.createdGuildPlatform.platformId)
           }
         })
       }

--- a/src/components/[guild]/collect/hooks/useCollectNft.ts
+++ b/src/components/[guild]/collect/hooks/useCollectNft.ts
@@ -4,12 +4,14 @@ import useNftDetails from "components/[guild]/collect/hooks/useNftDetails"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useUser from "components/[guild]/hooks/useUser"
 import { usePostHogContext } from "components/_app/PostHogProvider"
+import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import useNftBalance from "hooks/useNftBalance"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import useSubmit from "hooks/useSubmit"
 import { useToastWithTweetButton } from "hooks/useToast"
 import { useState } from "react"
 import guildRewardNftAbi from "static/abis/guildRewardNft"
+import { PlatformType } from "types"
 import { useFetcherWithSign } from "utils/fetcher"
 import processViemContractError from "utils/processViemContractError"
 import { TransactionReceipt } from "viem"
@@ -26,6 +28,7 @@ type ClaimData = {
 
 const useCollectNft = () => {
   const { captureEvent } = usePostHogContext()
+  const { rewardClaimed } = useCustomPosthogEvents()
   const { id: guildId, urlName } = useGuild()
   const { id: userId } = useUser()
   const postHogOptions = { guild: urlName }
@@ -117,6 +120,7 @@ const useCollectNft = () => {
   return {
     ...useSubmit<undefined, TransactionReceipt>(mint, {
       onSuccess: () => {
+        rewardClaimed(PlatformType.CONTRACT_CALL)
         setLoadingText("")
 
         refetchBalance()

--- a/src/components/[guild]/forms/FillForm.tsx
+++ b/src/components/[guild]/forms/FillForm.tsx
@@ -6,11 +6,13 @@ import Button from "components/common/Button"
 import Card from "components/common/Card"
 import FormErrorMessage from "components/common/FormErrorMessage"
 import DynamicDevTool from "components/create-guild/DynamicDevTool"
+import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import { useSubmitWithSign } from "hooks/useSubmit"
 import useToast from "hooks/useToast"
 import { useUserFormSubmission } from "platforms/Forms/hooks/useFormSubmissions"
 import { Controller, FormProvider, useForm } from "react-hook-form"
+import { PlatformType } from "types"
 import fetcher from "utils/fetcher"
 import useGuild from "../hooks/useGuild"
 import FillFormProgress from "./FillFormProgress"
@@ -38,6 +40,8 @@ const FillForm = ({ form }: Props) => {
 
   const { userSubmission, mutate: mutateSubmission } = useUserFormSubmission(form)
 
+  const { rewardClaimed } = useCustomPosthogEvents()
+
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
   const { onSubmit, isLoading } = useSubmitWithSign(
@@ -48,6 +52,7 @@ const FillForm = ({ form }: Props) => {
       }),
     {
       onSuccess: (res) => {
+        rewardClaimed(PlatformType.FORM)
         toast({
           status: "success",
           title: "Successfully submitted form",

--- a/src/components/create-guild/hooks/useCreateGuild.tsx
+++ b/src/components/create-guild/hooks/useCreateGuild.tsx
@@ -44,6 +44,16 @@ const useCreateGuild = ({
 
       captureEvent("guild creation flow > guild successfully created")
 
+      if (response_.guildPlatforms?.[0]) {
+        response_.guildPlatforms.forEach((guildPlatform) => {
+          captureEvent("reward created", {
+            platformName:
+              guildPlatform?.platformName ?? PlatformType[guildPlatform.platformId],
+            guild: response_?.urlName,
+          })
+        })
+      }
+
       if (response_.guildPlatforms?.[0]?.platformId === PlatformType.CONTRACT_CALL) {
         captureEvent("Created NFT reward", {
           hook: "useCreateGuild",

--- a/src/components/create-guild/hooks/useCreateGuild.tsx
+++ b/src/components/create-guild/hooks/useCreateGuild.tsx
@@ -46,7 +46,7 @@ const useCreateGuild = ({
 
       captureEvent("guild creation flow > guild successfully created")
 
-      if (response_.guildPlatforms?.[0]) {
+      if (response_.guildPlatforms?.length > 0) {
         response_.guildPlatforms.forEach((guildPlatform) => {
           rewardCreated(guildPlatform.platformId, response_?.urlName)
         })

--- a/src/components/create-guild/hooks/useCreateGuild.tsx
+++ b/src/components/create-guild/hooks/useCreateGuild.tsx
@@ -2,6 +2,7 @@ import processConnectorError from "components/[guild]/JoinModal/utils/processCon
 import { usePostHogContext } from "components/_app/PostHogProvider"
 import useJsConfetti from "components/create-guild/hooks/useJsConfetti"
 import { useYourGuilds } from "components/explorer/YourGuilds"
+import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import useMatchMutate from "hooks/useMatchMutate"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import { SignedValidation, useSubmitWithSign } from "hooks/useSubmit"
@@ -19,6 +20,7 @@ const useCreateGuild = ({
   onSuccess?: () => void
 } = {}) => {
   const { captureEvent } = usePostHogContext()
+  const { rewardCreated } = useCustomPosthogEvents()
 
   const { mutate: mutateYourGuilds } = useYourGuilds()
   const matchMutate = useMatchMutate()
@@ -46,11 +48,7 @@ const useCreateGuild = ({
 
       if (response_.guildPlatforms?.[0]) {
         response_.guildPlatforms.forEach((guildPlatform) => {
-          captureEvent("reward created", {
-            platformName:
-              guildPlatform?.platformName ?? PlatformType[guildPlatform.platformId],
-            guild: response_?.urlName,
-          })
+          rewardCreated(guildPlatform.platformId, response_?.urlName)
         })
       }
 

--- a/src/components/create-guild/hooks/useCreateRole.tsx
+++ b/src/components/create-guild/hooks/useCreateRole.tsx
@@ -1,13 +1,13 @@
 import processConnectorError from "components/[guild]/JoinModal/utils/processConnectorError"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useRoleGroup from "components/[guild]/hooks/useRoleGroup"
-import { usePostHogContext } from "components/_app/PostHogProvider"
 import useJsConfetti from "components/create-guild/hooks/useJsConfetti"
 import { useYourGuilds } from "components/explorer/YourGuilds"
+import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import useMatchMutate from "hooks/useMatchMutate"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import { SignedValidation, useSubmitWithSign } from "hooks/useSubmit"
-import { GuildBase, GuildPlatform, PlatformType, Requirement, Role } from "types"
+import { GuildBase, GuildPlatform, Requirement, Role } from "types"
 import fetcher from "utils/fetcher"
 import replacer from "utils/guildJsonReplacer"
 import preprocessRequirement from "utils/preprocessRequirement"
@@ -38,7 +38,7 @@ const useCreateRole = ({
 
   const { mutate: mutateYourGuilds } = useYourGuilds()
   const matchMutate = useMatchMutate()
-  const { captureEvent } = usePostHogContext()
+  const { rewardCreated } = useCustomPosthogEvents()
 
   const showErrorToast = useShowErrorToast()
   const triggerConfetti = useJsConfetti()
@@ -61,11 +61,7 @@ const useCreateRole = ({
 
       if (response_?.createdGuildPlatforms?.[0]) {
         response_.createdGuildPlatforms.forEach((guildPlatform) => {
-          captureEvent("reward created", {
-            platformName:
-              guildPlatform?.platformName ?? PlatformType[guildPlatform.platformId],
-            guild: urlName,
-          })
+          rewardCreated(guildPlatform.platformId, urlName)
         })
       }
 

--- a/src/components/create-guild/hooks/useCreateRole.tsx
+++ b/src/components/create-guild/hooks/useCreateRole.tsx
@@ -59,7 +59,7 @@ const useCreateRole = ({
     onSuccess: async (response_) => {
       triggerConfetti()
 
-      if (response_?.createdGuildPlatforms?.[0]) {
+      if (response_?.createdGuildPlatforms?.length > 0) {
         response_.createdGuildPlatforms.forEach((guildPlatform) => {
           rewardCreated(guildPlatform.platformId)
         })

--- a/src/components/create-guild/hooks/useCreateRole.tsx
+++ b/src/components/create-guild/hooks/useCreateRole.tsx
@@ -33,7 +33,7 @@ const useCreateRole = ({
   onSuccess?: () => void
   onError?: (error) => void
 }) => {
-  const { id, mutateGuild, urlName } = useGuild()
+  const { id, mutateGuild } = useGuild()
   const group = useRoleGroup()
 
   const { mutate: mutateYourGuilds } = useYourGuilds()
@@ -61,7 +61,7 @@ const useCreateRole = ({
 
       if (response_?.createdGuildPlatforms?.[0]) {
         response_.createdGuildPlatforms.forEach((guildPlatform) => {
-          rewardCreated(guildPlatform.platformId, urlName)
+          rewardCreated(guildPlatform.platformId)
         })
       }
 

--- a/src/components/create-guild/hooks/useCreateRole.tsx
+++ b/src/components/create-guild/hooks/useCreateRole.tsx
@@ -1,12 +1,13 @@
 import processConnectorError from "components/[guild]/JoinModal/utils/processConnectorError"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useRoleGroup from "components/[guild]/hooks/useRoleGroup"
+import { usePostHogContext } from "components/_app/PostHogProvider"
 import useJsConfetti from "components/create-guild/hooks/useJsConfetti"
 import { useYourGuilds } from "components/explorer/YourGuilds"
 import useMatchMutate from "hooks/useMatchMutate"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import { SignedValidation, useSubmitWithSign } from "hooks/useSubmit"
-import { GuildBase, GuildPlatform, Requirement, Role } from "types"
+import { GuildBase, GuildPlatform, PlatformType, Requirement, Role } from "types"
 import fetcher from "utils/fetcher"
 import replacer from "utils/guildJsonReplacer"
 import preprocessRequirement from "utils/preprocessRequirement"
@@ -32,11 +33,12 @@ const useCreateRole = ({
   onSuccess?: () => void
   onError?: (error) => void
 }) => {
-  const { id, mutateGuild } = useGuild()
+  const { id, mutateGuild, urlName } = useGuild()
   const group = useRoleGroup()
 
   const { mutate: mutateYourGuilds } = useYourGuilds()
   const matchMutate = useMatchMutate()
+  const { captureEvent } = usePostHogContext()
 
   const showErrorToast = useShowErrorToast()
   const triggerConfetti = useJsConfetti()
@@ -56,6 +58,16 @@ const useCreateRole = ({
     },
     onSuccess: async (response_) => {
       triggerConfetti()
+
+      if (response_?.createdGuildPlatforms?.[0]) {
+        response_.createdGuildPlatforms.forEach((guildPlatform) => {
+          captureEvent("reward created", {
+            platformName:
+              guildPlatform?.platformName ?? PlatformType[guildPlatform.platformId],
+            guild: urlName,
+          })
+        })
+      }
 
       mutateYourGuilds((prev) => mutateGuildsCache(prev, id), {
         revalidate: false,

--- a/src/hooks/useCustomPosthogEvents.ts
+++ b/src/hooks/useCustomPosthogEvents.ts
@@ -24,5 +24,13 @@ export default function useCustomPosthogEvents() {
         userId: id,
       })
     },
+
+    rewardClaimed(platformId: number) {
+      captureEvent("reward claimed", {
+        platformName: PlatformType[platformId],
+        guild: urlName,
+        userId: id,
+      })
+    },
   } as const
 }

--- a/src/hooks/useCustomPosthogEvents.ts
+++ b/src/hooks/useCustomPosthogEvents.ts
@@ -9,10 +9,11 @@ export default function useCustomPosthogEvents() {
   const { id } = useUser() ?? {}
 
   return {
-    rewardCreated(platformId: number, guild: string) {
+    rewardCreated(platformId: number, guild?: string) {
       captureEvent("reward created", {
         platformName: PlatformType[platformId],
-        guild,
+        guild: guild ?? urlName,
+        userId: id,
       })
     },
 

--- a/src/hooks/useCustomPosthogEvents.ts
+++ b/src/hooks/useCustomPosthogEvents.ts
@@ -1,0 +1,15 @@
+import { usePostHogContext } from "components/_app/PostHogProvider"
+import { PlatformType } from "types"
+
+export default function useCustomPosthogEvents() {
+  const { captureEvent } = usePostHogContext()
+
+  return {
+    rewardCreated(platformId: number, guild: string) {
+      captureEvent("reward created", {
+        platformName: PlatformType[platformId],
+        guild,
+      })
+    },
+  } as const
+}

--- a/src/hooks/useCustomPosthogEvents.ts
+++ b/src/hooks/useCustomPosthogEvents.ts
@@ -1,14 +1,26 @@
+import useGuild from "components/[guild]/hooks/useGuild"
+import useUser from "components/[guild]/hooks/useUser"
 import { usePostHogContext } from "components/_app/PostHogProvider"
 import { PlatformType } from "types"
 
 export default function useCustomPosthogEvents() {
   const { captureEvent } = usePostHogContext()
+  const { urlName } = useGuild() ?? {}
+  const { id } = useUser() ?? {}
 
   return {
     rewardCreated(platformId: number, guild: string) {
       captureEvent("reward created", {
         platformName: PlatformType[platformId],
         guild,
+      })
+    },
+
+    rewardGranted(platformId: number) {
+      captureEvent("reward granted", {
+        platformName: PlatformType[platformId],
+        guild: urlName,
+        userId: id,
       })
     },
   } as const

--- a/src/platforms/Forms/hooks/useFormSubmissions.tsx
+++ b/src/platforms/Forms/hooks/useFormSubmissions.tsx
@@ -2,11 +2,10 @@ import { Schemas } from "@guildxyz/types"
 import { sortAccounts } from "components/[guild]/crm/Identities"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useUser from "components/[guild]/hooks/useUser"
-import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import { useCallback, useMemo } from "react"
 import useSWRImmutable from "swr/immutable"
 import useSWRInfinite from "swr/infinite"
-import { PlatformAccountDetails, PlatformType } from "types"
+import { PlatformAccountDetails } from "types"
 import { useFetcherWithSign } from "utils/fetcher"
 
 type SubmissionAnswer = {
@@ -95,7 +94,6 @@ const useFormSubmissions = (formId, queryString) => {
 const useUserFormSubmission = (form: Schemas["Form"]) => {
   const { id } = useUser()
   const fetcherWithSign = useFetcherWithSign()
-  const { rewardClaimed } = useCustomPosthogEvents()
 
   const { data, ...rest } = useSWRImmutable<FormSubmission>(
     !!form && !!id
@@ -107,9 +105,6 @@ const useUserFormSubmission = (form: Schemas["Form"]) => {
     fetcherWithSign,
     {
       shouldRetryOnError: false,
-      onSuccess: () => {
-        rewardClaimed(PlatformType.FORM)
-      },
     }
   )
 

--- a/src/platforms/Forms/hooks/useFormSubmissions.tsx
+++ b/src/platforms/Forms/hooks/useFormSubmissions.tsx
@@ -2,10 +2,11 @@ import { Schemas } from "@guildxyz/types"
 import { sortAccounts } from "components/[guild]/crm/Identities"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useUser from "components/[guild]/hooks/useUser"
+import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import { useCallback, useMemo } from "react"
 import useSWRImmutable from "swr/immutable"
 import useSWRInfinite from "swr/infinite"
-import { PlatformAccountDetails } from "types"
+import { PlatformAccountDetails, PlatformType } from "types"
 import { useFetcherWithSign } from "utils/fetcher"
 
 type SubmissionAnswer = {
@@ -94,6 +95,7 @@ const useFormSubmissions = (formId, queryString) => {
 const useUserFormSubmission = (form: Schemas["Form"]) => {
   const { id } = useUser()
   const fetcherWithSign = useFetcherWithSign()
+  const { rewardClaimed } = useCustomPosthogEvents()
 
   const { data, ...rest } = useSWRImmutable<FormSubmission>(
     !!form && !!id
@@ -105,6 +107,9 @@ const useUserFormSubmission = (form: Schemas["Form"]) => {
     fetcherWithSign,
     {
       shouldRetryOnError: false,
+      onSuccess: () => {
+        rewardClaimed(PlatformType.FORM)
+      },
     }
   )
 

--- a/src/platforms/Gather/hooks/useClaimGather.tsx
+++ b/src/platforms/Gather/hooks/useClaimGather.tsx
@@ -2,10 +2,12 @@ import { useDisclosure } from "@chakra-ui/react"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useJsConfetti from "components/create-guild/hooks/useJsConfetti"
 import { useClaimedReward } from "hooks/useClaimedReward"
+import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import { SignedValidation, useSubmitWithSign } from "hooks/useSubmit"
 import { useSWRConfig } from "swr"
 import useSWRImmutable from "swr/immutable"
+import { PlatformType } from "types"
 import fetcher from "utils/fetcher"
 
 type ClaimResponse = {
@@ -24,6 +26,7 @@ const useClaimGather = (rolePlatformId: number) => {
 
   const triggerConfetti = useJsConfetti()
   const showErrorToast = useShowErrorToast()
+  const { rewardClaimed } = useCustomPosthogEvents()
 
   const endpoint = `/v2/guilds/${guildId}/roles/${roleId}/role-platforms/${rolePlatformId}/claim`
   const { data: responseFromCache, mutate: mutateCachedResponse } = useSWRImmutable(
@@ -40,6 +43,7 @@ const useClaimGather = (rolePlatformId: number) => {
   const { onSubmit: onClaimGatherSubmit, ...claim } =
     useSubmitWithSign<ClaimResponse>(claimFetcher, {
       onSuccess: (response) => {
+        rewardClaimed(PlatformType.GATHER_TOWN)
         triggerConfetti()
         /**
          * Saving in SWR cache so we don't need to re-claim the reward if the user

--- a/src/platforms/PolygonID/components/MintableRole.tsx
+++ b/src/platforms/PolygonID/components/MintableRole.tsx
@@ -14,10 +14,11 @@ import useUser from "components/[guild]/hooks/useUser"
 import Button from "components/common/Button"
 import GuildLogo from "components/common/GuildLogo"
 import { useRoleMembership } from "components/explorer/hooks/useMembership"
+import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import { SignedValidation, useSubmitWithSign } from "hooks/useSubmit"
 import useToast from "hooks/useToast"
-import { Role } from "types"
+import { PlatformType, Role } from "types"
 import fetcher from "utils/fetcher"
 import useClaimedRoles from "../hooks/useClaimedRoles"
 import PolygonIDQRCodeModal from "./PolygonIDQRCodeModal"
@@ -29,6 +30,7 @@ type Props = {
 const MintableRole = ({ role }: Props) => {
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
+  const { rewardClaimed } = useCustomPosthogEvents()
 
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { id: userId } = useUser()
@@ -54,6 +56,7 @@ const MintableRole = ({ role }: Props) => {
     claim,
     {
       onSuccess: () => {
+        rewardClaimed(PlatformType.POLYGON_ID)
         toast({
           status: "success",
           title: "Successfully minted proof",

--- a/src/platforms/Token/hooks/useCollectToken.tsx
+++ b/src/platforms/Token/hooks/useCollectToken.tsx
@@ -1,10 +1,12 @@
 import useGuild from "components/[guild]/hooks/useGuild"
 import { usePostHogContext } from "components/_app/PostHogProvider"
+import useCustomPosthogEvents from "hooks/useCustomPosthogEvents"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import useSubmit from "hooks/useSubmit"
 import { useToastWithTweetButton } from "hooks/useToast"
 import { useState } from "react"
 import tokenRewardPoolAbi from "static/abis/tokenRewardPool"
+import { PlatformType } from "types"
 import { useFetcherWithSign } from "utils/fetcher"
 import { ERC20_CONTRACTS } from "utils/guildCheckout/constants"
 import processViemContractError from "utils/processViemContractError"
@@ -39,6 +41,7 @@ const useCollectToken = (
   const fetcherWithSign = useFetcherWithSign()
   const publicClient = usePublicClient()
   const { data: walletClient } = useWalletClient()
+  const { rewardClaimed } = useCustomPosthogEvents()
 
   const collect = async () => {
     setLoadingText("Getting signature...")
@@ -64,6 +67,9 @@ const useCollectToken = (
         return
       })
       .then((res) => {
+        if (res) {
+          rewardClaimed(PlatformType.ERC20)
+        }
         const data: ClaimResponse = res.data
         // eslint-disable-next-line @typescript-eslint/naming-convention
         const [_poolId, _rolePlatformId, _amount, _signedAt, _userId, _signature] =


### PR DESCRIPTION
- Linear: https://linear.app/guildxyz/issue/GUILD-3003/reward-collection-by-guild-type
- Added a `useCustomPosthogEvents` hook. I think this is useful for events that get sent from multiple places. This way is is not possible to make a typo, or forget a param, or something similar
- Added events:
  - `reward created`: Sent when a guildPlatform is created by: guild creation, role creation, rolePlatform creation, or guildPlatform creation
  - `reward granted`: When a membership update is successful, we check the `newMembershipRoleIds` field, and send this event for all the rolePlatforms of those roles
    - [x] TODO: Filter them by membership
  - `reward claimed`: Sent when a reward is claimed by the `/claim` endpoint & when a form is submitted & when a polygonId is minted