### PR TITLE
fix: don't use `replace` from `useRouter` in dependency arrays

### DIFF
--- a/src/components/[guild]/forms/responses/FormResponsesTable.tsx
+++ b/src/components/[guild]/forms/responses/FormResponsesTable.tsx
@@ -43,7 +43,9 @@ const FormResponsesTable = ({ form }) => {
 
     const asPath = router.asPath.split("?")[0]
     router.replace(`${asPath}?${queryString}`)
-  }, [queryString, router])
+    // router.replace is intentionally left out
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryString, router.isReady, router.asPath])
 
   const { data, error, isLoading, isValidating, setSize } = useFormSubmissions(
     form.id,

--- a/src/hooks/useOAuthResultToast.ts
+++ b/src/hooks/useOAuthResultToast.ts
@@ -52,7 +52,8 @@ export default function useOAuthResultToast() {
 
       replace({ pathname, query: newQuery })
     }
-    /** Toast is intentionally left out, as it causes the toast to fire twice */
+    // replace is intentionally left out
+    // toast is intentionally left out, as it causes the toast to fire twice
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query, showPlatformMergeAlert, replace, pathname])
+  }, [query, showPlatformMergeAlert, pathname])
 }

--- a/src/hooks/useQueryState.ts
+++ b/src/hooks/useQueryState.ts
@@ -27,7 +27,9 @@ export const useQueryState = <State extends string>(
         scroll: false,
       })
     },
-    [name, router]
+    // router is intentionally left out
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [name]
   )
 
   return [state, toggle] as const

--- a/src/pages/[guild]/members.tsx
+++ b/src/pages/[guild]/members.tsx
@@ -151,7 +151,9 @@ const MembersPage = (): JSX.Element => {
 
     const path = asPath.split("?")[0]
     replace(`${path}?${queryString}`)
-  }, [isReady, queryString, asPath, replace])
+    // replace is intentionally left out
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isReady, queryString, asPath])
 
   const { data, error, isLoading, isValidating, setSize } = useMembers(queryString)
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -65,7 +65,8 @@ const App = ({
       router.events.off("routeChangeStart", handleRouteChangeStart)
       router.events.off("routeChangeComplete", handleRouteChangeComplete)
     }
-  }, [router.events])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <>


### PR DESCRIPTION
Seems like the methods from the `useRouter` hook aren't referentially stable, so when we included them in a `useEffect`'s dependency array, they caused infinite re-renders. Here is the related Next.js issue: https://github.com/vercel/next.js/issues/18127

Since they won't fix it in the pages directory, I just removed the router methods from dependency arrays.