### PR TITLE
fix(useSetRoleImageAndNameFromPlatformData): add early return to useEffect

### DIFF
--- a/src/components/[guild]/AddRewardButton/hooks/useSetRoleImageAndNameFromPlatformData.ts
+++ b/src/components/[guild]/AddRewardButton/hooks/useSetRoleImageAndNameFromPlatformData.ts
@@ -3,13 +3,14 @@ import {
   useAddRewardContext,
 } from "components/[guild]/AddRewardContext"
 import usePinata from "hooks/usePinata/usePinata"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useFormContext } from "react-hook-form"
 
 const useSetRoleImageAndNameFromPlatformData = (
   platformImage: string,
   platformName: string
 ) => {
+  const [alreadyUploaded, setAlreadyUploaded] = useState(false)
   const { activeTab } = useAddRewardContext()
 
   const { setValue } = useFormContext()
@@ -25,8 +26,19 @@ const useSetRoleImageAndNameFromPlatformData = (
   }, [activeTab, platformName, setValue])
 
   useEffect(() => {
-    if (activeTab !== RoleTypeToAddTo.NEW_ROLE || !(platformImage?.length > 0))
+    if (
+      alreadyUploaded ||
+      activeTab !== RoleTypeToAddTo.NEW_ROLE ||
+      !(platformImage?.length > 0)
+    )
       return
+
+    setAlreadyUploaded(true)
+
+    if (platformImage?.startsWith(process.env.NEXT_PUBLIC_IPFS_GATEWAY)) {
+      setValue("imageUrl", platformImage)
+      return
+    }
 
     fetch(platformImage)
       .then((response) => response.blob())
@@ -35,7 +47,7 @@ const useSetRoleImageAndNameFromPlatformData = (
           data: [new File([blob], `${platformName}.png`, { type: "image/png" })],
         })
       )
-  }, [activeTab, platformImage, platformName, onUpload])
+  }, [alreadyUploaded, activeTab, platformImage, setValue, platformName, onUpload])
 }
 
 export default useSetRoleImageAndNameFromPlatformData


### PR DESCRIPTION
This hook ran too many times & called the Pinata API constantly, which is not the expected behavior. As a quick fix, I added an extra `alreadyUploaded` state & an early return, and also added a condition so we don't re-upload the image if we already uploaded it to IPFS. Let me know if you have a better idea, not sure how could we handle this properly.