### PR TITLE
refactor(useEditGuildPlatform): send the whole `platformGuildData` object to our API

### DIFF
--- a/src/components/[guild]/RoleCard/components/EditNFTDescriptionModal.tsx
+++ b/src/components/[guild]/RoleCard/components/EditNFTDescriptionModal.tsx
@@ -28,8 +28,8 @@ const EditNFTModalContent: React.FC<ContentProps> = ({
   guildPlatform: { id, platformGuildData },
   onClose,
 }) => {
-  const { formState, control, handleSubmit } = useForm({
-    defaultValues: { ...platformGuildData },
+  const { formState, control, handleSubmit } = useForm<{ description: string }>({
+    defaultValues: { description: platformGuildData.description },
   })
 
   const toast = useToast()

--- a/src/platforms/Poap/PoapCardButton.tsx
+++ b/src/platforms/Poap/PoapCardButton.tsx
@@ -60,7 +60,6 @@ const PoapCardButton = ({ platform }: Props) => {
               isOpen={isOpen}
               onClose={onClose}
               guildPlatformId={platform?.id}
-              platformGuildData={platform?.platformGuildData}
             />
           </>
         ) : (

--- a/src/platforms/Poap/PoapCardMenu.tsx
+++ b/src/platforms/Poap/PoapCardMenu.tsx
@@ -31,7 +31,6 @@ const PoapCardMenu = ({ platformGuildId }: Props): JSX.Element => {
         isOpen={isOpen}
         onClose={onClose}
         guildPlatformId={guildPlatform?.id}
-        platformGuildData={guildPlatform?.platformGuildData}
       />
     </>
   )

--- a/src/platforms/Poap/UploadMintLinksModal.tsx
+++ b/src/platforms/Poap/UploadMintLinksModal.tsx
@@ -13,21 +13,14 @@ import Button from "components/common/Button"
 import { Modal } from "components/common/Modal"
 import useToast from "hooks/useToast"
 import { FormProvider, useForm, useWatch } from "react-hook-form"
-import { GuildPlatform } from "types"
 
 type Props = {
   isOpen: boolean
   onClose: () => void
   guildPlatformId: number
-  platformGuildData: GuildPlatform["platformGuildData"]
 }
 
-const UploadMintLinksModal = ({
-  isOpen,
-  onClose,
-  guildPlatformId,
-  platformGuildData,
-}: Props) => {
+const UploadMintLinksModal = ({ isOpen, onClose, guildPlatformId }: Props) => {
   const methods = useForm<ImportPoapForm>()
   const texts = useWatch({ name: "texts", control: methods.control })
 
@@ -46,7 +39,6 @@ const UploadMintLinksModal = ({
   const onEditPoapRewardSubmit = (data: ImportPoapForm) =>
     onSubmit({
       platformGuildData: {
-        ...platformGuildData,
         texts: data.texts?.filter(Boolean),
       },
     })

--- a/src/platforms/UniqueText/UniqueTextDataForm.tsx
+++ b/src/platforms/UniqueText/UniqueTextDataForm.tsx
@@ -40,7 +40,7 @@ const UniqueTextDataForm = ({
     name: "texts",
     rules: {
       validate: (value) => {
-        if (!shouldValidate) return
+        if (!shouldValidate || !value) return
         if (1000 < value.length) return "You can upload up to 1000 lines."
 
         const wrongIndex = value.findIndex((line) => 100 < line.length)


### PR DESCRIPTION
Our API rewrites the `platformGuildData` object when we edit it, so we always need to send both the unmodified and modified data. I refactored this hook, so we won't need to handle this logic where we use the `useEditGuildPlatform` hook.