### PR TITLE
Bug fix: display linked accounts when there is only 1

### DIFF
--- a/src/components/common/Layout/components/Account/components/AccountModal/components/AccountConnections.tsx
+++ b/src/components/common/Layout/components/Account/components/AccountModal/components/AccountConnections.tsx
@@ -87,7 +87,7 @@ const AccountConnections = () => {
       <AccountSection divider={<Divider />}>
         {isLoading ? (
           <LinkedAddressSkeleton />
-        ) : !(addresses?.length > 1) ? (
+        ) : !(addresses?.length > 0) ? (
           <Stack
             {...(!vaults?.length && {
               direction: "row",


### PR DESCRIPTION
Fixes bug where no linked addresses are shown when only 1 address is connected

Before: 
<img width="1510" alt="Screenshot 2024-05-18 at 11 38 10 AM" src="https://github.com/guildxyz/guild.xyz/assets/24376928/78fdc668-2529-4cb7-a15f-7ca65c907893">

After:
<img width="1510" alt="Screenshot 2024-05-18 at 11 38 17 AM" src="https://github.com/guildxyz/guild.xyz/assets/24376928/6ff9a6ad-406a-4dd6-bc1e-7f81b04cd5b9">
