### PR TITLE
[GUILD-3074] - List already added DC servers in setup grid

### DIFF
--- a/src/components/[guild]/AddRewardButton/hooks/useAddRoleRewards.ts
+++ b/src/components/[guild]/AddRewardButton/hooks/useAddRoleRewards.ts
@@ -1,0 +1,48 @@
+import useGuild from "components/[guild]/hooks/useGuild"
+import { usePostHogContext } from "components/_app/PostHogProvider"
+import useShowErrorToast from "hooks/useShowErrorToast"
+import useSubmit from "hooks/useSubmit"
+import useToast from "hooks/useToast"
+import { useFetcherWithSign } from "utils/fetcher"
+
+const useAddRoleRewards = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void
+  onError?: (err: unknown) => void
+}) => {
+  const { id, urlName, memberCount, mutateGuild } = useGuild()
+
+  const { captureEvent } = usePostHogContext()
+  const postHogOptions = { guild: urlName, memberCount }
+
+  const showErrorToast = useShowErrorToast()
+  const toast = useToast()
+  const fetcherWithSign = useFetcherWithSign()
+
+  const fetchData = async (body) =>
+    Promise.all(
+      body?.roleIds.map((roleId) =>
+        fetcherWithSign([
+          `/v2/guilds/${id}/roles/${roleId}/role-platforms`,
+          { body, method: "POST" },
+        ])
+      )
+    )
+
+  return useSubmit(fetchData, {
+    onError: (error) => {
+      showErrorToast(error)
+      captureEvent("useAddRoleReward error", { ...postHogOptions, error })
+      onError?.(error)
+    },
+    onSuccess: () => {
+      toast({ status: "success", title: "Reward successfully added" })
+      mutateGuild()
+      onSuccess?.()
+    },
+  })
+}
+
+export default useAddRoleRewards

--- a/src/components/[guild]/AddRewardButton/hooks/useSubmitAddReward.ts
+++ b/src/components/[guild]/AddRewardButton/hooks/useSubmitAddReward.ts
@@ -106,6 +106,8 @@ const useSubmitAddReward = () => {
 
     const existingDCReward = guildPlatforms?.find(
       (gp) =>
+        data?.rolePlatforms?.[0]?.guildPlatform?.platformId ===
+          PlatformType.DISCORD &&
         data?.rolePlatforms?.[0]?.guildPlatform?.platformId === gp.platformId &&
         data?.rolePlatforms?.[0]?.guildPlatform?.platformGuildId ===
           gp.platformGuildId

--- a/src/components/[guild]/AddRewardButton/hooks/useSubmitAddReward.ts
+++ b/src/components/[guild]/AddRewardButton/hooks/useSubmitAddReward.ts
@@ -11,6 +11,7 @@ import { defaultValues } from "../AddRewardButton"
 import useCreateReqBasedTokenReward from "../useCreateTokenReward"
 import useAddReward from "./useAddReward"
 import { useAddRewardDiscardAlert } from "./useAddRewardDiscardAlert"
+import useAddRoleRewards from "./useAddRoleRewards"
 
 const isERC20 = (data) =>
   data.rolePlatforms[0].guildPlatform.platformId === PlatformType.ERC20
@@ -19,7 +20,7 @@ const useSubmitAddReward = () => {
   const toast = useToast()
   const { selection, onClose: onAddRewardModalClose } = useAddRewardContext()
   const [, setIsAddRewardPanelDirty] = useAddRewardDiscardAlert()
-  const { roles } = useGuild()
+  const { roles, guildPlatforms } = useGuild()
   const { captureEvent } = usePostHogContext()
 
   const methods = useFormContext()
@@ -60,7 +61,18 @@ const useSubmitAddReward = () => {
       },
     })
 
-  const isLoading = isAddRewardLoading || isCreateRoleLoading || erc20Loading
+  const { onSubmit: onAddRoleRewardSubmit, isLoading: isAddRoleRewardLoading } =
+    useAddRoleRewards({
+      onSuccess: () => {
+        onCloseAndClear()
+      },
+    })
+
+  const isLoading =
+    isAddRewardLoading ||
+    isCreateRoleLoading ||
+    erc20Loading ||
+    isAddRoleRewardLoading
 
   const submitERC20Reward = async (
     data: any,
@@ -92,6 +104,23 @@ const useSubmitAddReward = () => {
   const onSubmit = async (data: any, saveAs: "DRAFT" | "PUBLIC" = "PUBLIC") => {
     if (isERC20(data)) return submitERC20Reward(data, saveAs)
 
+    const existingDCReward = guildPlatforms?.find(
+      (gp) =>
+        data?.rolePlatforms?.[0]?.guildPlatform?.platformId === gp.platformId &&
+        data?.rolePlatforms?.[0]?.guildPlatform?.platformGuildId ===
+          gp.platformGuildId
+    )
+
+    if (existingDCReward && data.rolePlatforms[0]) {
+      data.rolePlatforms[0].guildPlatform = existingDCReward
+      data.rolePlatforms[0].guildPlatformId = existingDCReward.id
+
+      if (!data.rolePlatforms[0].platformRoleId) {
+        // Delete any falsy values
+        delete data.rolePlatforms[0].platformRoleId
+      }
+    }
+
     if (data.requirements?.length > 0) {
       const roleVisibility =
         saveAs === "DRAFT" ? Visibility.HIDDEN : Visibility.PUBLIC
@@ -104,6 +133,11 @@ const useSubmitAddReward = () => {
           ...rp,
           visibility: roleVisibility,
         })),
+      })
+    } else if (existingDCReward) {
+      onAddRoleRewardSubmit({
+        roleIds: data?.roleIds ?? [],
+        ...data?.rolePlatforms?.[0],
       })
     } else {
       onAddRewardSubmit({

--- a/src/components/[guild]/NoRolesAlert.tsx
+++ b/src/components/[guild]/NoRolesAlert.tsx
@@ -9,9 +9,13 @@ import Card from "components/common/Card"
 
 type Props = {
   type?: "GUILD" | "GROUP"
+  areAllRolesInUse?: boolean
 }
 
-const NoRolesAlert = ({ type = "GUILD" }: Props): JSX.Element => {
+const NoRolesAlert = ({
+  type = "GUILD",
+  areAllRolesInUse = false,
+}: Props): JSX.Element => {
   const entity = type === "GUILD" ? "guild" : "page"
 
   return (
@@ -19,9 +23,15 @@ const NoRolesAlert = ({ type = "GUILD" }: Props): JSX.Element => {
       <Alert status="info">
         <AlertIcon boxSize="5" mr="2" mt="1px" />
         <Stack>
-          <AlertTitle>No public roles</AlertTitle>
+          <AlertTitle>
+            {areAllRolesInUse
+              ? "All the roles have this reward already"
+              : "No public roles"}
+          </AlertTitle>
           <AlertDescription>
-            {`It seems like this ${entity} doesn't have any public roles. There might be some secret / hidden ones that you can unlock though!`}
+            {areAllRolesInUse
+              ? `It seems like all the roles within this ${entity} have this reward already. You can create a new role, and add this reward to it!`
+              : `It seems like this ${entity} doesn't have any public roles. There might be some secret / hidden ones that you can unlock though!`}
           </AlertDescription>
         </Stack>
       </Alert>

--- a/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/AddRoleRewardModal.tsx
+++ b/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/AddRoleRewardModal.tsx
@@ -1,6 +1,7 @@
 import { ModalOverlay, Text, useDisclosure } from "@chakra-ui/react"
 import { useAddRewardDiscardAlert } from "components/[guild]/AddRewardButton/hooks/useAddRewardDiscardAlert"
 import { useAddRewardContext } from "components/[guild]/AddRewardContext"
+import useGuild from "components/[guild]/hooks/useGuild"
 import DiscardAlert from "components/common/DiscardAlert"
 import { Modal } from "components/common/Modal"
 import rewards, {
@@ -17,7 +18,8 @@ type Props = {
 }
 
 const AddRoleRewardModal = ({ append }: Props) => {
-  const { selection, step, isOpen, onClose } = useAddRewardContext()
+  const { selection, step, isOpen, onClose, targetRoleId } = useAddRewardContext()
+  const { guildPlatforms } = useGuild()
 
   const {
     isOpen: isDiscardAlertOpen,
@@ -33,7 +35,21 @@ const AddRoleRewardModal = ({ append }: Props) => {
   const isRewardSetupStep = selection && step !== "HOME" && step !== "SELECT_ROLE"
 
   const handleAddReward = (data: any) => {
-    append({ ...data, visibility: roleVisibility })
+    const rolePlatformWithGuildPlatform = { ...data, visibility: roleVisibility }
+
+    const existingGuildPlatform = guildPlatforms?.find(
+      (gp) =>
+        gp.platformId === data.guildPlatform?.platformId &&
+        gp.platformGuildId === data.guildPlatform?.platformGuildId
+    )
+
+    if (existingGuildPlatform) {
+      rolePlatformWithGuildPlatform.guildPlatform = existingGuildPlatform
+      rolePlatformWithGuildPlatform.roleId = targetRoleId
+      rolePlatformWithGuildPlatform.guildPlatformId = existingGuildPlatform.id
+    }
+
+    append(rolePlatformWithGuildPlatform)
     onClose()
   }
 

--- a/src/components/[guild]/RoleSelector.tsx
+++ b/src/components/[guild]/RoleSelector.tsx
@@ -9,11 +9,13 @@ type Props = {
   roles: Role[]
   size?: "md" | "lg"
   allowMultiple?: boolean
+  isGuildPlatformAlreadyInUse?: boolean
 } & CheckboxGroupProps
 
 const DynamicNoRolesAlert = dynamic(() => import("components/[guild]/NoRolesAlert"))
 
 const RoleSelector = ({
+  isGuildPlatformAlreadyInUse = false,
   roles,
   size,
   allowMultiple = true,
@@ -24,7 +26,14 @@ const RoleSelector = ({
 
   const group = useRoleGroup()
 
-  if (!roles?.length) return <DynamicNoRolesAlert type={group ? "GROUP" : "GUILD"} />
+  if (!roles?.length) {
+    return (
+      <DynamicNoRolesAlert
+        type={group ? "GROUP" : "GUILD"}
+        areAllRolesInUse={isGuildPlatformAlreadyInUse}
+      />
+    )
+  }
 
   return (
     <CheckboxGroup

--- a/src/components/common/DiscordGuildSetup/DiscordGuildSetup.tsx
+++ b/src/components/common/DiscordGuildSetup/DiscordGuildSetup.tsx
@@ -46,6 +46,7 @@ const DiscordGuildSetup = ({
   useAddRewardDiscardAlert(!!selectedServer)
 
   const { captureEvent } = usePostHogContext()
+  const { id } = useGuild()
 
   const {
     gateables: unorderedServers,
@@ -59,7 +60,13 @@ const DiscordGuildSetup = ({
       captureEvent("[discord setup] gateables failed, showing reconnect alert")
     },
   })
-  const servers = unorderedServers?.sort((a, b) => +a.isGuilded - +b.isGuilded)
+  const servers = unorderedServers?.sort(
+    (a, b) =>
+      // Order servers, which are already used in the guild to the very top, then other selectable ones, then the guilded ones
+      +a.isGuilded +
+      +(b.isGuilded && b.guildId === id) * 2 -
+      (+b.isGuilded + +(a.isGuilded && a.guildId === id) * 2)
+  )
 
   const selectedServerOption = useMemo(
     () => servers?.find((server) => server.id === selectedServer?.id),

--- a/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
@@ -54,6 +54,19 @@ const DCServerCard = ({
 
   const isUsedInCurrentGuild = serverData.isGuilded && serverData.guildId === id
 
+  const selectButton = (
+    <Button
+      h={10}
+      colorScheme="green"
+      onClick={() => {
+        onSelect()
+      }}
+      data-test="select-dc-server-button"
+    >
+      Select
+    </Button>
+  )
+
   return (
     <CardMotionWrapper>
       <OptionCard
@@ -62,13 +75,15 @@ const DCServerCard = ({
         description={serverData.owner ? "Owner" : "Admin"}
         image={serverData.img || "/default_discord_icon.png"}
       >
-        {!isUsedInCurrentGuild && isSelected ? (
+        {isUsedInCurrentGuild ? (
+          selectButton
+        ) : isSelected ? (
           <Button h={10} onClick={onCancel}>
             Cancel
           </Button>
-        ) : !isUsedInCurrentGuild && isValidating ? (
+        ) : isValidating ? (
           <Button isLoading />
-        ) : !isUsedInCurrentGuild && serverData.isGuilded ? (
+        ) : serverData.isGuilded ? (
           <Button
             as={Link}
             href={`/${serverData.guildId}`}
@@ -80,16 +95,7 @@ const DCServerCard = ({
             Linked guild
           </Button>
         ) : (
-          <Button
-            h={10}
-            colorScheme="green"
-            onClick={() => {
-              onSelect()
-            }}
-            data-test="select-dc-server-button"
-          >
-            Select
-          </Button>
+          selectButton
         )}
       </OptionCard>
     </CardMotionWrapper>

--- a/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
@@ -26,12 +26,14 @@ const DCServerCard = ({
 }: Props): JSX.Element => {
   const { id } = useGuild() ?? {}
 
+  const isUsedInCurrentGuild = serverData.isGuilded && serverData.guildId === id
+
   const {
     mutate,
     isValidating,
     permissions: existingPermissions,
     error,
-  } = useServerPermissions(serverData?.id)
+  } = useServerPermissions(serverData?.id, !isUsedInCurrentGuild)
 
   const onSelect = async () => {
     try {
@@ -51,8 +53,6 @@ const DCServerCard = ({
       onSelectProp()
     }
   }
-
-  const isUsedInCurrentGuild = serverData.isGuilded && serverData.guildId === id
 
   const selectButton = (
     <Button

--- a/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
@@ -37,6 +37,10 @@ const DCServerCard = ({
 
   const onSelect = async () => {
     try {
+      if (isUsedInCurrentGuild) {
+        onSubmit()
+      }
+
       if (error) {
         return
       }

--- a/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
+++ b/src/components/common/DiscordGuildSetup/components/DCServerCard.tsx
@@ -54,8 +54,6 @@ const DCServerCard = ({
 
   const isUsedInCurrentGuild = serverData.isGuilded && serverData.guildId === id
 
-  if (isUsedInCurrentGuild) return null
-
   return (
     <CardMotionWrapper>
       <OptionCard
@@ -64,13 +62,13 @@ const DCServerCard = ({
         description={serverData.owner ? "Owner" : "Admin"}
         image={serverData.img || "/default_discord_icon.png"}
       >
-        {isSelected ? (
+        {!isUsedInCurrentGuild && isSelected ? (
           <Button h={10} onClick={onCancel}>
             Cancel
           </Button>
-        ) : isValidating ? (
+        ) : !isUsedInCurrentGuild && isValidating ? (
           <Button isLoading />
-        ) : serverData.isGuilded ? (
+        ) : !isUsedInCurrentGuild && serverData.isGuilded ? (
           <Button
             as={Link}
             href={`/${serverData.guildId}`}

--- a/src/hooks/useServerPermissions.ts
+++ b/src/hooks/useServerPermissions.ts
@@ -43,12 +43,12 @@ function mapPermissions(permissions: PermissionsResponse) {
   }
 }
 
-export default function useServerPermissions(serverId: string) {
-  const shouldFetch = serverId?.length > 0
+export default function useServerPermissions(serverId: string, shouldFetch = true) {
+  const shouldFetchFinal = shouldFetch && serverId?.length > 0
   const { data, error, isLoading, isValidating, mutate } = useSWRImmutable<
     ReturnType<typeof mapPermissions>
   >(
-    shouldFetch ? `/v2/discord/servers/${serverId}/permissions` : null,
+    shouldFetchFinal ? `/v2/discord/servers/${serverId}/permissions` : null,
     (url) => fetcher(url).then(mapPermissions),
     { shouldRetryOnError: false, revalidateOnMount: false }
   )

--- a/src/platforms/components/SelectRoleOrSetRequirements.tsx
+++ b/src/platforms/components/SelectRoleOrSetRequirements.tsx
@@ -23,15 +23,36 @@ const TAB_STYLE_PROPS: TabProps = {
 }
 
 const SelectRoleOrSetRequirements = ({ isRoleSelectorDisabled }: Props) => {
-  const { roles } = useGuild()
+  const { roles, guildPlatforms } = useGuild()
   const group = useRoleGroup()
+  const data = useWatch({ name: `rolePlatforms.0` })
+
+  const existingGuildPlatform = guildPlatforms?.find(
+    (gp) =>
+      gp.platformId === data?.guildPlatform?.platformId &&
+      gp.platformGuildId === data?.guildPlatform?.platformGuildId
+  )
+
+  const alreadyUsedRoles = new Set(
+    existingGuildPlatform
+      ? roles
+          ?.filter((role) =>
+            role.rolePlatforms?.some(
+              (rp) => rp.guildPlatformId === existingGuildPlatform.id
+            )
+          )
+          ?.map((role) => role.id) ?? []
+      : []
+  )
+
+  const availableRoles = roles.filter((role) => !alreadyUsedRoles.has(role.id))
+
   const relevantRoles = group
-    ? roles.filter((role) => role.groupId === group.id)
-    : roles.filter((role) => !role.groupId)
+    ? availableRoles.filter((role) => role.groupId === group.id)
+    : availableRoles.filter((role) => !role.groupId)
 
   const { register, unregister, setValue } = useFormContext()
   const { selection, activeTab, setActiveTab } = useAddRewardContext()
-  const data = useWatch({ name: `rolePlatforms.0` })
 
   const erc20Type: "REQUIREMENT_AMOUNT" | "STATIC" | null =
     selection === "ERC20" ? data?.dynamicAmount.operation.input.type : null
@@ -79,6 +100,7 @@ const SelectRoleOrSetRequirements = ({ isRoleSelectorDisabled }: Props) => {
       <TabPanels>
         <TabPanel>
           <RoleSelector
+            isGuildPlatformAlreadyInUse={!!existingGuildPlatform}
             allowMultiple={
               selection !== "ERC20"
                 ? asRewardRestriction === PlatformAsRewardRestrictions.MULTIPLE_ROLES


### PR DESCRIPTION
This PR adds the functionality for selecting DC servers, which are already added to a guild
- Both adding with the guild page _add reward_ button, and to an existing role should work, if you try the preview out, please check out both
- When adding through the guild page _add reward_ button, only those roles should be listed, which don't already have the selected server as a reward