### PR TITLE
[GUILD-3083] - fix: sanitize discord invite links

### DIFF
--- a/src/components/[guild]/AccessHub/components/usePlatformAccessButton.tsx
+++ b/src/components/[guild]/AccessHub/components/usePlatformAccessButton.tsx
@@ -5,6 +5,18 @@ import useToast from "hooks/useToast"
 import rewards from "platforms/rewards"
 import { GuildPlatform, PlatformName, PlatformType } from "types"
 
+function sanitizeInviteLink(inviteLink: string) {
+  if (inviteLink.startsWith("https://")) {
+    return inviteLink
+  }
+
+  if (inviteLink.startsWith("http://")) {
+    return inviteLink.replace("http://", "https://")
+  }
+
+  return `https://${inviteLink}`
+}
+
 const usePlatformAccessButton = (
   platform: GuildPlatform
 ): { label: string } & LinkProps & ButtonProps => {
@@ -43,7 +55,7 @@ const usePlatformAccessButton = (
       label: `Go to ${rewards[platformName].gatedEntity}`,
       as: "a",
       target: "_blank",
-      href: platform.invite,
+      href: sanitizeInviteLink(platform.invite),
     }
 
   return {


### PR DESCRIPTION
[Linear](https://linear.app/guildxyz/issue/GUILD-3083/invalid-discord-server-link)

- Once we use zod schemas more for BE-side input validation & sanitization, we can solve this easily on that side as well, which would be a better solution
- For now, I think this solution will be fine, as for now this is mainly intended to fix the issue in this Guild: https://guild.xyz/degenwars