### PR TITLE
[GUILD-3132] fix: convert only relevant elements of the url to lowercase

### DIFF
--- a/src/requirements/VisitLink/VisitLinkForm.tsx
+++ b/src/requirements/VisitLink/VisitLinkForm.tsx
@@ -57,7 +57,12 @@ const VisitLinkForm = ({ baseFieldPath }: RequirementFormProps) => {
         placeholder="https://guild.xyz"
         onChange={(e) => {
           const position = e.target.selectionStart
-          onChange(new URL(e.target.value).href)
+          try {
+            const parsedUrl = new URL(e.target.value).href
+            onChange(parsedUrl)
+          } catch {
+            onChange(e.target.value)
+          }
           // The cursor's position was always set to e.target.value.length without timeout
           setTimeout(() => {
             e.target.setSelectionRange(position, position)

--- a/src/requirements/VisitLink/VisitLinkForm.tsx
+++ b/src/requirements/VisitLink/VisitLinkForm.tsx
@@ -57,11 +57,7 @@ const VisitLinkForm = ({ baseFieldPath }: RequirementFormProps) => {
         placeholder="https://guild.xyz"
         onChange={(e) => {
           const position = e.target.selectionStart
-          onChange(
-            e.target.value.toLowerCase().includes("youtube")
-              ? e.target.value
-              : e.target.value.toLowerCase()
-          )
+          onChange(new URL(e.target.value).href)
           // The cursor's position was always set to e.target.value.length without timeout
           setTimeout(() => {
             e.target.setSelectionRange(position, position)


### PR DESCRIPTION
The `URL` API by default converts elements in the *origin* to lowercase.