### PR TITLE
[GUILD-3104] - WaaS: Change backup data export feature to private key export

### DIFF
--- a/src/components/common/Layout/components/Account/components/AccountModal/AccountModal.tsx
+++ b/src/components/common/Layout/components/Account/components/AccountModal/AccountModal.tsx
@@ -18,7 +18,7 @@ import {
   useDisclosure,
 } from "@chakra-ui/react"
 import useUser, { useUserPublic } from "components/[guild]/hooks/useUser"
-import CopyCWaaSBackupData from "components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/GoogleLoginButton/components/CopyCWaaSBackupData"
+import CopyWaaSPrivateKey from "components/_app/Web3ConnectionManager/components/WalletSelectorModal/components/GoogleLoginButton/components/CopyWaaSPrivateKey"
 import useConnectorNameAndIcon from "components/_app/Web3ConnectionManager/hooks/useConnectorNameAndIcon"
 import useWeb3ConnectionManager from "components/_app/Web3ConnectionManager/hooks/useWeb3ConnectionManager"
 import Button from "components/common/Button"
@@ -138,7 +138,7 @@ const AccountModal = () => {
                   />
                 </Stack>
                 <HStack spacing={1}>
-                  {connector?.id === WAAS_CONNECTOR_ID && <CopyCWaaSBackupData />}
+                  {connector?.id === WAAS_CONNECTOR_ID && <CopyWaaSPrivateKey />}
                   <Tooltip label="Disconnect">
                     <IconButton
                       size="sm"

--- a/src/wagmiConfig/waasConnector.ts
+++ b/src/wagmiConfig/waasConnector.ts
@@ -223,6 +223,20 @@ export default function waasConnector(options: InitializeWaasOptions) {
         throw new WaasActionFailed(error)
       }
     },
+
+    async exportKeys(backupData: string) {
+      try {
+        await this.getProvider()
+        throwIfNoWallet()
+
+        const privateKey = await waas.wallets.wallet.exportKeys(backupData)
+
+        return privateKey
+      } catch (error) {
+        console.error(error)
+        throw new WaasActionFailed(error)
+      }
+    },
   }))
 }
 


### PR DESCRIPTION
[Linear](https://linear.app/guildxyz/issue/GUILD-3104/coinbase-data-import) - [Discord](https://discord.com/channels/697041998728659035/1169587223956570232/1247473523816140821)

- This is needed for the user linked in the Linear ticket, and once we transition to Smart Wallet, we will need this option for current waas users
- Can be tested by:
  1. Connecting with waas
  2. Taking note of the address
  3. Exporting the private key
  4. Importing the wallet into MetaMask (or other wallet)
  5. Checking if the imported wallet's address is the same as the one noted earlier