### PR TITLE
[GUILD-2197] - refactor: move complicated `useEffect` logic in `useUserPublic`

### DIFF
--- a/src/components/[guild]/hooks/useUser.ts
+++ b/src/components/[guild]/hooks/useUser.ts
@@ -105,9 +105,7 @@ const useUserPublic = (
       }
 
       // If we didn't set the keyPair field, the user either doesn't have one locally, or has an invalid one
-      const shouldOpenWalletSelectorModal = !user.keyPair
-
-      if (shouldOpenWalletSelectorModal && !ignoredRoutes.includes(router.route)) {
+      if (!user.keyPair && !ignoredRoutes.includes(router.route)) {
         setIsWalletSelectorModalOpen(true)
       }
 

--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -22,7 +22,6 @@ import { Modal } from "components/common/Modal"
 import ModalButton from "components/common/ModalButton"
 import useSetKeyPair from "hooks/useSetKeyPair"
 import { useAtom, useSetAtom } from "jotai"
-import { useRouter } from "next/router"
 import { ArrowLeft, ArrowSquareOut } from "phosphor-react"
 import { useEffect } from "react"
 import { useAccount, useConnect, type Connector } from "wagmi"
@@ -43,18 +42,9 @@ type Props = {
   onOpen: () => void
 }
 
-// We don't open the modal on these routes
-const ignoredRoutes = [
-  "/_error",
-  "/tgauth",
-  "/oauth",
-  "/googleauth",
-  "/oauth-result",
-]
-
 const COINBASE_INJECTED_WALLET_ID = "com.coinbase.wallet"
 
-const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element => {
+const WalletSelectorModal = ({ isOpen, onClose }: Props): JSX.Element => {
   const { isWeb3Connected, isInSafeContext, disconnect } = useWeb3ConnectionManager()
 
   const { connectors, error, connect, variables, isPending } = useConnect()
@@ -105,19 +95,6 @@ const WalletSelectorModal = ({ isOpen, onClose, onOpen }: Props): JSX.Element =>
   useEffect(() => {
     if (keyPair && !isAddressLink) onClose()
   }, [keyPair, isAddressLink, onClose])
-
-  const router = useRouter()
-
-  useEffect(() => {
-    if (
-      ((!!id && !keyPair) || !!publicUserError) &&
-      router.isReady &&
-      !ignoredRoutes.includes(router.route) &&
-      !!connector?.connect
-    ) {
-      onOpen()
-    }
-  }, [keyPair, router, id, publicUserError, connector, onOpen])
 
   const isConnectedAndKeyPairReady = isWeb3Connected && !!id
 


### PR DESCRIPTION
- This seems to be a much simpler solution. One less `useEffect` always feels like a good idea
- Tested by:
  - I connected my wallet, refreshed the page, and the modal appeared
  - I invalidated my key, and reloaded the page, and both the toast appears, and the modal opened
  - Temporarily added `/explorer` to the ignored routes array, and the modal no longer open