### PR TITLE
fix: token reward setup stuck at pool creation

### DIFF
--- a/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddTokenPanel/components/PoolStep.tsx
+++ b/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddTokenPanel/components/PoolStep.tsx
@@ -145,6 +145,7 @@ const PoolStep = ({ onSubmit }: { onSubmit: () => void }) => {
               defaultValue={1}
               numberInputFieldProps={{ pr: 7, pl: 10 }}
               width={"full"}
+              validateMinMax={false}
             />
           </InputGroup>
         </FormControl>

--- a/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddTokenPanel/components/PoolStep.tsx
+++ b/src/components/[guild]/RolePlatforms/components/AddRoleRewardModal/components/AddTokenPanel/components/PoolStep.tsx
@@ -22,11 +22,7 @@ import { useEffect, useState } from "react"
 import { useController, useFormContext, useWatch } from "react-hook-form"
 import ControlledNumberInput from "requirements/WalletActivity/components/ControlledNumberInput"
 import Token from "static/icons/token.svg"
-import {
-  ERC20_CONTRACTS,
-  MIN_TOKEN_AMOUNT,
-  NULL_ADDRESS,
-} from "utils/guildCheckout/constants"
+import { ERC20_CONTRACTS, NULL_ADDRESS } from "utils/guildCheckout/constants"
 import { parseUnits } from "viem"
 import { useAccount } from "wagmi"
 import { Chains } from "wagmiConfig/chains"
@@ -140,12 +136,10 @@ const PoolStep = ({ onSubmit }: { onSubmit: () => void }) => {
             <ControlledNumberInput
               numberFormat="FLOAT"
               name="amount"
-              min={MIN_TOKEN_AMOUNT}
               isDisabled={skip}
               defaultValue={1}
               numberInputFieldProps={{ pr: 7, pl: 10 }}
               width={"full"}
-              validateMinMax={false}
             />
           </InputGroup>
         </FormControl>

--- a/src/requirements/WalletActivity/components/ControlledNumberInput.tsx
+++ b/src/requirements/WalletActivity/components/ControlledNumberInput.tsx
@@ -18,6 +18,7 @@ type Props = {
   decimalsMax?: number
   replaceMin?: boolean
   replaceMax?: boolean
+  validateMinMax?: boolean
   numberInputFieldProps?: NumberInputFieldProps
 } & NumberInputProps
 
@@ -29,6 +30,7 @@ const ControlledNumberInput = ({
   numberFormat = "INT",
   adaptiveStepSize = false,
   decimalsMax = MAX_DECIMALS,
+  validateMinMax = true,
   ...props
 }: Props): JSX.Element => {
   const {
@@ -37,14 +39,16 @@ const ControlledNumberInput = ({
     name: props.name,
     rules: {
       required: props.isRequired && "This field is required",
-      min: props.min && {
-        value: props.min,
-        message: `Minimum: ${props.min}`,
-      },
-      max: props.max && {
-        value: props.max,
-        message: `Maximum: ${props.max}`,
-      },
+      ...(validateMinMax && {
+        min: props.min && {
+          value: props.min,
+          message: `Minimum: ${props.min}`,
+        },
+        max: props.max && {
+          value: props.max,
+          message: `Maximum: ${props.max}`,
+        },
+      }),
     },
     defaultValue: props.defaultValue,
   })

--- a/src/requirements/WalletActivity/components/ControlledNumberInput.tsx
+++ b/src/requirements/WalletActivity/components/ControlledNumberInput.tsx
@@ -18,7 +18,6 @@ type Props = {
   decimalsMax?: number
   replaceMin?: boolean
   replaceMax?: boolean
-  validateMinMax?: boolean
   numberInputFieldProps?: NumberInputFieldProps
 } & NumberInputProps
 
@@ -30,7 +29,6 @@ const ControlledNumberInput = ({
   numberFormat = "INT",
   adaptiveStepSize = false,
   decimalsMax = MAX_DECIMALS,
-  validateMinMax = true,
   ...props
 }: Props): JSX.Element => {
   const {
@@ -39,16 +37,14 @@ const ControlledNumberInput = ({
     name: props.name,
     rules: {
       required: props.isRequired && "This field is required",
-      ...(validateMinMax && {
-        min: props.min && {
-          value: props.min,
-          message: `Minimum: ${props.min}`,
-        },
-        max: props.max && {
-          value: props.max,
-          message: `Maximum: ${props.max}`,
-        },
-      }),
+      min: props.min && {
+        value: props.min,
+        message: `Minimum: ${props.min}`,
+      },
+      max: props.max && {
+        value: props.max,
+        message: `Maximum: ${props.max}`,
+      },
     },
     defaultValue: props.defaultValue,
   })


### PR DESCRIPTION
When creating a token reward, the flow got stuck at the pool creation. It would create the pool, but not move on.
Turns out we had a min value validation on the amount field that should not be there.