### PR TITLE
Improve and fix `PaymentForm`, prevent JS scientific notation conversion

### DIFF
--- a/src/requirements/Payment/PaymentForm.tsx
+++ b/src/requirements/Payment/PaymentForm.tsx
@@ -2,7 +2,7 @@ import { HStack, Icon, Stack, Tooltip } from "@chakra-ui/react"
 import Button from "components/common/Button"
 import useTriggerNetworkChange from "hooks/useTriggerNetworkChange"
 import { Check, Question } from "phosphor-react"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { FormProvider, useForm, useFormContext, useWatch } from "react-hook-form"
 import { RequirementFormProps } from "requirements"
 import { FEE_COLLECTOR_CONTRACT } from "utils/guildCheckout/constants"
@@ -62,9 +62,13 @@ const PaymentForm = ({
       setValue(`${baseFieldPath}.data.id`, registeredVaultId),
   })
 
+  const isRequirementAdded = useRef(false)
   useEffect(() => {
     if (!vaultId) return
-    addRequirement()
+    if (!isRequirementAdded.current) {
+      addRequirement()
+      isRequirementAdded.current = true
+    }
   }, [vaultId, addRequirement])
 
   useEffect(() => {

--- a/src/requirements/Payment/PaymentForm.tsx
+++ b/src/requirements/Payment/PaymentForm.tsx
@@ -2,7 +2,7 @@ import { HStack, Icon, Stack, Tooltip } from "@chakra-ui/react"
 import Button from "components/common/Button"
 import useTriggerNetworkChange from "hooks/useTriggerNetworkChange"
 import { Check, Question } from "phosphor-react"
-import { useEffect, useRef } from "react"
+import { useEffect } from "react"
 import { FormProvider, useForm, useFormContext, useWatch } from "react-hook-form"
 import { RequirementFormProps } from "requirements"
 import { FEE_COLLECTOR_CONTRACT } from "utils/guildCheckout/constants"
@@ -62,13 +62,9 @@ const PaymentForm = ({
       setValue(`${baseFieldPath}.data.id`, registeredVaultId),
   })
 
-  const isRequirementAdded = useRef(false)
   useEffect(() => {
     if (!vaultId) return
-    if (!isRequirementAdded.current) {
-      addRequirement()
-      isRequirementAdded.current = true
-    }
+    addRequirement()
   }, [vaultId, addRequirement])
 
   useEffect(() => {

--- a/src/requirements/Payment/PaymentForm.tsx
+++ b/src/requirements/Payment/PaymentForm.tsx
@@ -12,7 +12,6 @@ import RegisterVaultForm, {
   RegisterVaultFormType,
 } from "./components/RegisterVaultForm"
 import useRegisterVault from "./components/RegisterVaultForm/hooks/useRegisterVault"
-import useDebouncedState from "hooks/useDebouncedState"
 
 const PaymentForm = ({
   baseFieldPath,
@@ -63,12 +62,10 @@ const PaymentForm = ({
       setValue(`${baseFieldPath}.data.id`, registeredVaultId),
   })
 
-  const debouncedVaultId = useDebouncedState(vaultId, 200)
-
   useEffect(() => {
-    if (!debouncedVaultId) return
+    if (!vaultId) return
     addRequirement()
-  }, [debouncedVaultId, addRequirement])
+  }, [vaultId, addRequirement])
 
   useEffect(() => {
     if (isLoading)

--- a/src/requirements/Payment/PaymentForm.tsx
+++ b/src/requirements/Payment/PaymentForm.tsx
@@ -12,6 +12,7 @@ import RegisterVaultForm, {
   RegisterVaultFormType,
 } from "./components/RegisterVaultForm"
 import useRegisterVault from "./components/RegisterVaultForm/hooks/useRegisterVault"
+import useDebouncedState from "hooks/useDebouncedState"
 
 const PaymentForm = ({
   baseFieldPath,
@@ -62,10 +63,12 @@ const PaymentForm = ({
       setValue(`${baseFieldPath}.data.id`, registeredVaultId),
   })
 
+  const debouncedVaultId = useDebouncedState(vaultId, 200)
+
   useEffect(() => {
-    if (!vaultId) return
+    if (!debouncedVaultId) return
     addRequirement()
-  }, [vaultId, addRequirement])
+  }, [debouncedVaultId, addRequirement])
 
   useEffect(() => {
     if (isLoading)

--- a/src/requirements/Payment/components/RegisterVaultForm/RegisterVaultForm.tsx
+++ b/src/requirements/Payment/components/RegisterVaultForm/RegisterVaultForm.tsx
@@ -46,16 +46,17 @@ type Props = {
 
 const RegisterVaultForm = ({ isDisabled }: Props): JSX.Element => {
   const {
+    control,
     register,
     setValue,
     formState: { errors },
   } = useFormContext<RegisterVaultFormType>()
-  const chain = useWatch({ name: "chain" })
-  const token = useWatch({ name: "token" })
+  const chain = useWatch({ control, name: "chain" })
+  const token = useWatch({ control, name: "token" })
 
   const { data: tokenData } = useToken({
     address: token,
-    chainId: Chains[chain as keyof typeof Chains],
+    chainId: Chains[chain],
     shouldFetch: Boolean(token !== NULL_ADDRESS && chain),
   })
   const chainId = useChainId()

--- a/src/requirements/Payment/components/RegisterVaultForm/RegisterVaultForm.tsx
+++ b/src/requirements/Payment/components/RegisterVaultForm/RegisterVaultForm.tsx
@@ -14,6 +14,7 @@ import {
   Text,
 } from "@chakra-ui/react"
 import FormErrorMessage from "components/common/FormErrorMessage"
+import useToken from "hooks/useToken"
 import { useController, useFormContext, useWatch } from "react-hook-form"
 import useFeeInUSD from "requirements/Payment/components/RegisterVaultForm/hooks/useFeeInUSD"
 import ChainPicker from "requirements/common/ChainPicker"
@@ -23,7 +24,8 @@ import {
   NULL_ADDRESS,
   paymentSupportedChains,
 } from "utils/guildCheckout/constants"
-import { Chain } from "wagmiConfig/chains"
+import { useChainId } from "wagmi"
+import { CHAIN_CONFIG, Chain, Chains } from "wagmiConfig/chains"
 
 const coingeckoCoinIds: Partial<Record<Chain, string>> = {
   ETHEREUM: "ethereum",
@@ -34,7 +36,7 @@ const coingeckoCoinIds: Partial<Record<Chain, string>> = {
 export type RegisterVaultFormType = {
   chain: Chain
   token: `0x${string}`
-  fee: number
+  fee: string
   owner: `0x${string}`
 }
 
@@ -49,6 +51,29 @@ const RegisterVaultForm = ({ isDisabled }: Props): JSX.Element => {
     formState: { errors },
   } = useFormContext<RegisterVaultFormType>()
   const chain = useWatch({ name: "chain" })
+  const token = useWatch({ name: "token" })
+
+  const { data: tokenData } = useToken({
+    address: token,
+    chainId: Chains[chain as keyof typeof Chains],
+    shouldFetch: Boolean(token !== NULL_ADDRESS && chain),
+  })
+  const chainId = useChainId()
+
+  const validateFee = (value: string): boolean | string => {
+    const tokenDecimals =
+      token === NULL_ADDRESS
+        ? CHAIN_CONFIG[Chains[chainId] as keyof typeof CHAIN_CONFIG].nativeCurrency
+            .decimals
+        : tokenData?.decimals
+    const lastDotIndex = value.lastIndexOf(".")
+    const decimalPrecision = value.slice(lastDotIndex + 1).length
+    if (decimalPrecision > tokenDecimals) {
+      return `Decimal places must not exceed ${tokenDecimals} digits.`
+    }
+
+    return true
+  }
 
   const {
     field: {
@@ -66,16 +91,18 @@ const RegisterVaultForm = ({ isDisabled }: Props): JSX.Element => {
         value: 0,
         message: "Amount must be positive",
       },
+      validate: validateFee,
     },
   })
 
-  const handleFeeChange = (newValue, onChange) => {
-    if (/^[0-9]*\.0*$/i.test(newValue)) return onChange(newValue)
-    const parsedValue = parseFloat(newValue)
-    return onChange(isNaN(parsedValue) ? "" : parsedValue)
-  }
+  const handleFeeChange = (valueAsString: string) => {
+    const legalChars = "0123456789."
+    const filteredInput = [...valueAsString]
+      .filter((char) => legalChars.includes(char))
+      .join("")
 
-  const token = useWatch({ name: "token" })
+    feeFieldOnChange(filteredInput)
+  }
 
   const { feeInUSD } = useFeeInUSD(
     feeFieldValue,
@@ -98,13 +125,14 @@ const RegisterVaultForm = ({ isDisabled }: Props): JSX.Element => {
 
         <InputGroup>
           <NumberInput
-            isDisabled={isDisabled}
+            isDisabled={isDisabled || !token || !chain}
             w="full"
             ref={feeFieldRef}
             value={feeFieldValue ?? undefined}
-            onChange={(newValue) => handleFeeChange(newValue, feeFieldOnChange)}
-            onBlur={feeFieldOnBlur}
             min={0}
+            clampValueOnBlur={false}
+            onChange={(valueAsString) => handleFeeChange(valueAsString)}
+            onBlur={feeFieldOnBlur}
             sx={
               feeInUSD > 0 && {
                 "> input": {

--- a/src/requirements/Payment/components/RegisterVaultForm/RegisterVaultForm.tsx
+++ b/src/requirements/Payment/components/RegisterVaultForm/RegisterVaultForm.tsx
@@ -126,7 +126,7 @@ const RegisterVaultForm = ({ isDisabled }: Props): JSX.Element => {
 
         <InputGroup>
           <NumberInput
-            isDisabled={isDisabled || !token || !chain}
+            isDisabled={isDisabled || !tokenData || !token || !chain}
             w="full"
             ref={feeFieldRef}
             value={feeFieldValue ?? undefined}

--- a/src/requirements/Payment/components/RegisterVaultForm/RegisterVaultForm.tsx
+++ b/src/requirements/Payment/components/RegisterVaultForm/RegisterVaultForm.tsx
@@ -64,8 +64,7 @@ const RegisterVaultForm = ({ isDisabled }: Props): JSX.Element => {
   const validateFee = (value: string): boolean | string => {
     const tokenDecimals =
       token === NULL_ADDRESS
-        ? CHAIN_CONFIG[Chains[chainId] as keyof typeof CHAIN_CONFIG].nativeCurrency
-            .decimals
+        ? CHAIN_CONFIG[Chains[chainId] as Chain].nativeCurrency.decimals
         : tokenData?.decimals
     const lastDotIndex = value.lastIndexOf(".")
     const decimalPrecision = value.slice(lastDotIndex + 1).length

--- a/src/requirements/Payment/components/RegisterVaultForm/hooks/useRegisterVault.ts
+++ b/src/requirements/Payment/components/RegisterVaultForm/hooks/useRegisterVault.ts
@@ -35,8 +35,7 @@ const useRegisterVault = ({
   })
   const tokenDecimals =
     token === NULL_ADDRESS
-      ? CHAIN_CONFIG[Chains[chainId] as keyof typeof CHAIN_CONFIG].nativeCurrency
-          .decimals
+      ? CHAIN_CONFIG[Chains[chainId] as Chain].nativeCurrency.decimals
       : tokenData?.decimals
 
   const feeInWei = fee && tokenDecimals ? parseUnits(fee, tokenDecimals) : undefined

--- a/src/requirements/Payment/components/RegisterVaultForm/hooks/useRegisterVault.ts
+++ b/src/requirements/Payment/components/RegisterVaultForm/hooks/useRegisterVault.ts
@@ -35,7 +35,8 @@ const useRegisterVault = ({
   })
   const tokenDecimals =
     token === NULL_ADDRESS
-      ? CHAIN_CONFIG[Chains[chainId]].nativeCurrency.decimals
+      ? CHAIN_CONFIG[Chains[chainId] as keyof typeof CHAIN_CONFIG].nativeCurrency
+          .decimals
       : tokenData?.decimals
   const feeInWei =
     fee && tokenDecimals ? parseUnits(fee.toString(), tokenDecimals) : undefined
@@ -45,7 +46,10 @@ const useRegisterVault = ({
   return useSubmitTransaction(
     {
       abi: feeCollectorAbi,
-      address: FEE_COLLECTOR_CONTRACT[Chains[chainId]],
+      address:
+        FEE_COLLECTOR_CONTRACT[
+          Chains[chainId] as keyof typeof FEE_COLLECTOR_CONTRACT
+        ],
       functionName: "registerVault",
       args: registerVaultParams,
       chainId: Chains[chain],

--- a/src/requirements/Payment/components/RegisterVaultForm/hooks/useRegisterVault.ts
+++ b/src/requirements/Payment/components/RegisterVaultForm/hooks/useRegisterVault.ts
@@ -12,7 +12,7 @@ import { CHAIN_CONFIG, Chain, Chains } from "wagmiConfig/chains"
 type RegisterVaultParams = {
   owner: `0x${string}`
   token: `0x${string}`
-  fee: number
+  fee: string
   chain: Chain
 }
 
@@ -38,8 +38,8 @@ const useRegisterVault = ({
       ? CHAIN_CONFIG[Chains[chainId] as keyof typeof CHAIN_CONFIG].nativeCurrency
           .decimals
       : tokenData?.decimals
-  const feeInWei =
-    fee && tokenDecimals ? parseUnits(fee.toString(), tokenDecimals) : undefined
+
+  const feeInWei = fee && tokenDecimals ? parseUnits(fee, tokenDecimals) : undefined
 
   const registerVaultParams = [owner, token, false, BigInt(feeInWei ?? 0)] as const
 


### PR DESCRIPTION
This PR prevents error: https://jam.dev/c/d88f9e28-bddf-46f4-a8a7-5a668a43b3c8

Added validation to make sure the token precision is not exceeded, `parseFloat` is replaced by string as JS numbers are unreliable for this kind of use case.