### PR TITLE
fix(WalletSelectorModal): error alert description

### DIFF
--- a/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/src/components/_app/Web3ConnectionManager/components/WalletSelectorModal/WalletSelectorModal.tsx
@@ -157,11 +157,12 @@ const WalletSelectorModal = ({ isOpen, onClose }: Props): JSX.Element => {
                     return {
                       title: "Error",
                       description:
-                        err?.message ?? typeof err?.error === "string"
+                        err?.message ??
+                        (typeof err?.error === "string"
                           ? err?.error
                           : typeof err === "string"
                           ? err
-                          : err?.errors?.[0]?.msg,
+                          : err?.errors?.[0]?.msg),
                     }
                   },
                 }


### PR DESCRIPTION
- We commonly have bug reports where this alert's description is empty
- This PR changes up the description conditions a bit
  - I've just put everything after `err?.message ?? ` in parentheses
  - Previously the first part of the conditions meant `(err?.message ?? typeof err?.error === "string") ? err?.error : ...`
  - Not it is `err?.message ?? (typeof err?.error === "string" ? err?.error : ...)`