### PR TITLE
[GUILD-3226] - `useUserPublic` fixes

### DIFF
--- a/src/components/[guild]/hooks/useUser.ts
+++ b/src/components/[guild]/hooks/useUser.ts
@@ -110,6 +110,12 @@ const useUserPublic = (
       }
 
       return user
+    },
+    {
+      shouldRetryOnError: false,
+      onError: () => {
+        setIsWalletSelectorModalOpen(true)
+      },
     }
   )
 


### PR DESCRIPTION
[Linear](https://linear.app/guildxyz/issue/GUILD-3226/useuserpublic-open-walletselectormodal-onerror-and-dont-retry-on-error)

- There is a small bug with account verification:
  1. Log out of your current account
  2. Login with a fresh wallet (the easiest way is to do this with a new Smart Wallet)
  3. Don't click the verify button, instead refresh the page
  4. When the page refreshes, you should see that your wallet is connected, but you don't get a verification modal
- This PR aims to fix this by opening the modal in `useUserPublic`'s `onError`
- Also sets `shouldRetryOnError` to false, as it is expected to return an error if the user doesn't exist, there is no need to fetch 5 more times