### PR TITLE
fix(PointsRequirement): display points from external guilds

### DIFF
--- a/src/requirements/Points/PointsRequirement.tsx
+++ b/src/requirements/Points/PointsRequirement.tsx
@@ -26,7 +26,7 @@ const ExternalGuildLink = ({ name, urlName }) => (
 const PointsRank = (props: RequirementProps): JSX.Element => {
   const requirement = useRequirementContext()
   const { guildId, minAmount, maxAmount } = requirement.data
-  const { name, urlName } = useGuild(guildId)
+  const { name, urlName } = useSimpleGuild(guildId)
   const { id: currentGuildId } = useGuild()
 
   const pointsReward = usePointsRewardForCurrentRequirement()
@@ -54,7 +54,7 @@ const PointsRank = (props: RequirementProps): JSX.Element => {
 const PointsTotalAmount = (props: RequirementProps): JSX.Element => {
   const requirement = useRequirementContext()
   const { guildId, minAmount, maxAmount } = requirement.data
-  const { name, urlName } = useGuild(guildId)
+  const { name, urlName } = useSimpleGuild(guildId)
   const { id: currentGuildId } = useGuild()
 
   return (


### PR DESCRIPTION
Turns out we weren't able to display points from external guilds, so this PR aims to fix that! I also changed the `useGuild(guildId)` call to a `useSimpleGuild(guildId)` + a `GET /guilds/:guildId/guild-plaftorms`, because it's more efficient than fetching the whole `/guild-page` of another guild.