### PR TITLE
fix(Collect page): always add the relevant guildPlatform to the SWR cache

### DIFF
--- a/src/pages/[guild]/collect/[chain]/[address].tsx
+++ b/src/pages/[guild]/collect/[chain]/[address].tsx
@@ -278,6 +278,10 @@ const getStaticProps = async ({ params }) => {
     .then((res) => res.json())
     .catch(() => undefined)
 
+  const isPublicNFT = !!publicGuild.guildPlatforms.find(
+    (gp) => gp.id === nftGuildReward.id
+  )
+
   return {
     revalidate: 600, // Revalidate at most once every 10 minutes
     props: {
@@ -293,7 +297,9 @@ const getStaticProps = async ({ params }) => {
         [guildPageEndpoint]: {
           ...publicGuild,
           // An NFT is always public (it can be found on the blockchain), so we can add the guildPlatform to the public guild cache
-          guildPlatforms: [...publicGuild.guildPlatforms, nftGuildReward],
+          guildPlatforms: isPublicNFT
+            ? publicGuild.guildPlatforms
+            : [...publicGuild.guildPlatforms, nftGuildReward],
         },
         [`/v2/guilds/${publicGuild.id}/roles/${nftRole.id}/requirements`]:
           publicGuild.roles.find((r) => r.id === nftRole.id)?.requirements ?? [],

--- a/src/pages/[guild]/collect/[chain]/[address].tsx
+++ b/src/pages/[guild]/collect/[chain]/[address].tsx
@@ -290,7 +290,11 @@ const getStaticProps = async ({ params }) => {
       fallbackImage: nftGuildReward.platformGuildData.imageUrl,
       // Pre-populating the public guild & requirements caches
       fallback: {
-        [guildPageEndpoint]: publicGuild,
+        [guildPageEndpoint]: {
+          ...publicGuild,
+          // An NFT is always public (it can be found on the blockchain), so we can add the guildPlatform to the public guild cache
+          guildPlatforms: [...publicGuild.guildPlatforms, nftGuildReward],
+        },
         [`/v2/guilds/${publicGuild.id}/roles/${nftRole.id}/requirements`]:
           publicGuild.roles.find((r) => r.id === nftRole.id)?.requirements ?? [],
         ...(!!nftDetails


### PR DESCRIPTION
We had a client-side error in cases when the NFT reward wasn't public in a guild. I think we can safely "leak" the `guildPlatform` here, since NFTs are public by default (they're on chain rewards), but let me know if you have any other suggestions!