### PR TITLE
feat: enable `strictNullChecks` during development

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Open source interface for Guild.xyz -- a tool for platformless membership manage
 
 Open [http://localhost:3000](http://localhost:3000) in your browser to see the result.
 
+> [!WARNING]
+> We've recently turned on `strict` and `strictNullChecks` tsconfig options, and decided to gradually fix the related TypeScript issues. The pre-commit hook will ignore these, but it is expected that you'll see different issues during local development. Feel free to open a PR if you fix some of them. :wink:
+
 #### For Windows users
 
 If you encounter the error `ERR_OSSL_EVP_UNSUPPORTED` you can do :

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,9 @@ const { BugsnagSourceMapUploaderPlugin } = require("webpack-bugsnag-plugins")
 
 /** @type {import("next").NextConfig} */
 const nextConfig = {
+  typescript: {
+    tsconfigPath: process.env.TS_CONFIG_PATH,
+  },
   webpack(config, options) {
     config.module.rules.push({
       test: /\.svg$/,

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "prepare": "npm run snyk-protect && husky install",
     "dev": "next dev",
-    "build": "next build",
+    "build": "TS_CONFIG_PATH='./tsconfig.build.json' next build",
     "start": "next start",
-    "type-check": "tsc --pretty --noEmit --incremental false",
+    "type-check": "tsc --pretty --noEmit --incremental false --strict false --strictNullChecks false",
     "format": "prettier --write .",
     "lint": "next lint",
     "lint-fix": "eslint --fix . --ext .ts,.tsx,.js,.jsx",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "TS_CONFIG_PATH='./tsconfig.build.json' next build",
     "start": "next start",
-    "type-check": "tsc --pretty --noEmit --incremental false --strict false --strictNullChecks false",
+    "type-check": "tsc --pretty --noEmit --incremental false --project './tsconfig.build.json'",
     "format": "prettier --write .",
     "lint": "next lint",
     "lint-fix": "eslint --fix . --ext .ts,.tsx,.js,.jsx",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": false,
+    "strictNullChecks": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
@@ -22,7 +22,7 @@
         "name": "next"
       }
     ],
-    "strictNullChecks": false
+    "strictNullChecks": true
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
The idea is to set `strict` & `strictNullChecks` to `true` in our TS config, but set them to `false` (their current value) in the pre-commit hook & during build, so we could gradually fix the issues caused by these settings during development, but our app will build without errors in prod. 