### PR TITLE
feat(activity log): don't fetch `click join on web` actions

### DIFF
--- a/src/components/[guild]/activity/ActivityLogAction/components/ActionLabel.tsx
+++ b/src/components/[guild]/activity/ActivityLogAction/components/ActionLabel.tsx
@@ -151,13 +151,12 @@ const ActionLabel = (): JSX.Element => {
                 )}
               </>
             )
-          case ACTION.ClickJoinOnWeb:
+          case ACTION.JoinGuild:
             return (
               <>
-                <Text as="span">Join Guild through website</Text>
-                {showGuildTag ? (
-                  <ClickableGuildTag guildId={ids.guild} />
-                ) : (
+                <Text as="span">Join Guild</Text>
+                {showGuildTag && <ClickableGuildTag guildId={ids.guild} />}
+                {activityLogType !== "user" && (
                   <ClickableUserTag userId={ids.user} />
                 )}
               </>
@@ -196,7 +195,6 @@ const ActionLabel = (): JSX.Element => {
             const isChildOfUserStatusUpdate = [
               ACTION.UserStatusUpdate,
               ACTION.JoinGuild,
-              ACTION.ClickJoinOnWeb,
               ACTION.ClickJoinOnPlatform,
               ACTION.LeaveGuild,
             ].includes(parentaction)

--- a/src/components/[guild]/activity/ActivityLogContext.tsx
+++ b/src/components/[guild]/activity/ActivityLogContext.tsx
@@ -162,7 +162,11 @@ const ActivityLogProvider = ({
         ? ADMIN_ACTIONS
         : actionGroup === ActivityLogActionGroup.UserAction
         ? USER_ACTIONS
-        : []
+        : /**
+           * Adding all actions to the query by default in order to make sure we don't fetch
+           * unsupported ones (e.g. the "click join on web" action)
+           */
+          [...USER_ACTIONS, ...ADMIN_ACTIONS]
 
     actions.forEach((action) => {
       searchParams.append("action", action.toString())

--- a/src/components/[guild]/activity/constants.ts
+++ b/src/components/[guild]/activity/constants.ts
@@ -68,7 +68,6 @@ export enum ACTION {
   RestartStatusUpdate = "restart status update",
   StopStatusUpdate = "stop status update",
   // User
-  ClickJoinOnWeb = "click join on web",
   ClickJoinOnPlatform = "click join on platform",
   JoinGuild = "join guild",
   LeaveGuild = "leave guild",
@@ -234,10 +233,6 @@ export const activityLogActionIcons: Record<
     as: ArrowsClockwise,
     color: "red.500",
   },
-  [ACTION.ClickJoinOnWeb]: {
-    as: SignIn,
-    color: "green.500",
-  },
   [ACTION.ClickJoinOnPlatform]: {
     as: SignIn,
     color: "green.500",
@@ -329,7 +324,6 @@ export const HIDDEN_ACTIONS: ACTION[] = [
 ]
 
 export const USER_ACTIONS: ACTION[] = [
-  ACTION.ClickJoinOnWeb,
   ACTION.ClickJoinOnPlatform,
   ACTION.JoinGuild,
   ACTION.LeaveGuild,


### PR DESCRIPTION
The `join guild` action was a child action of `click join on web` before, but now it's also a parent action, so we can use the former one. The original `click join on web` was a bit misleading, since it is triggered for access checks too.

Relevant backend PR: https://github.com/guildxyz/guild-backend/pull/1529