### PR TITLE
feat: hidden pages

### DIFF
--- a/src/components/[guild]/AccessHub/components/CampaignCards/CampaignCards.tsx
+++ b/src/components/[guild]/AccessHub/components/CampaignCards/CampaignCards.tsx
@@ -3,10 +3,15 @@ import {
   HStack,
   Img,
   SkeletonCircle,
+  Tag,
+  TagLabel,
+  TagLeftIcon,
   Text,
+  Tooltip,
+  VStack,
   useColorModeValue,
 } from "@chakra-ui/react"
-import { ArrowRight, Plus } from "@phosphor-icons/react"
+import { ArrowRight, EyeSlash, Plus } from "@phosphor-icons/react"
 import useGuild from "components/[guild]/hooks/useGuild"
 import useGuildPermission from "components/[guild]/hooks/useGuildPermission"
 import Button from "components/common/Button"
@@ -36,11 +41,21 @@ const CampaignCards = () => {
 
   if (!groups?.length || !!query.group) return null
 
+  const renderedGroups = isAdmin
+    ? groups
+    : groups.filter((group) => !group.hideFromGuildPage)
+
   return (
     <>
-      {groups.map(({ id, imageUrl, name, urlName }) => {
-        const groupHasRoles = roles.some((role) => role.groupId === id)
+      {renderedGroups.map(({ id, imageUrl, name, urlName, hideFromGuildPage }) => {
+        const groupHasRoles = roles?.some((role) => role.groupId === id)
         if (!isAdmin && !groupHasRoles) return null
+
+        let campaignImage = ""
+        if (typeof imageUrl === "string" && imageUrl.length > 0)
+          campaignImage = imageUrl
+        else if (typeof guildImageUrl === "string" && guildImageUrl.length > 0)
+          campaignImage = guildImageUrl
 
         return (
           <ColorCard
@@ -55,7 +70,7 @@ const CampaignCards = () => {
             {isAdmin && <DynamicCampaignCardMenu groupId={id} />}
 
             <HStack spacing={3} minHeight={10} mb={5}>
-              {imageUrl?.length > 0 || guildImageUrl?.length > 0 ? (
+              {campaignImage.length > 0 ? (
                 <Circle
                   overflow={"hidden"}
                   borderRadius="full"
@@ -64,21 +79,31 @@ const CampaignCards = () => {
                   position="relative"
                   bgColor={imageBgColor}
                 >
-                  {imageUrl?.match("guildLogos") ? (
-                    <Img src={imageUrl} alt="Guild logo" boxSize="40%" />
+                  {campaignImage.match("guildLogos") ? (
+                    <Img src={campaignImage} alt="Guild logo" boxSize="40%" />
                   ) : (
-                    <Image
-                      src={imageUrl || guildImageUrl}
-                      alt={name}
-                      fill
-                      sizes="2.5rem"
-                    />
+                    <Image src={campaignImage} alt={name} fill sizes="2.5rem" />
                   )}
                 </Circle>
               ) : (
                 <SkeletonCircle size="10" />
               )}
-              <Text fontWeight="bold">{name}</Text>
+
+              <VStack alignItems="start">
+                <Text fontWeight="bold">{name}</Text>
+                {hideFromGuildPage && (
+                  <Tooltip
+                    label="This page is hidden from your guild's home page"
+                    hasArrow
+                    placement="bottom"
+                  >
+                    <Tag>
+                      <TagLeftIcon as={EyeSlash} />
+                      <TagLabel>Hidden</TagLabel>
+                    </Tag>
+                  </Tooltip>
+                )}
+              </VStack>
             </HStack>
 
             {groupHasRoles ? (

--- a/src/components/[guild]/AccessHub/components/CampaignCards/CampaignCards.tsx
+++ b/src/components/[guild]/AccessHub/components/CampaignCards/CampaignCards.tsx
@@ -93,7 +93,7 @@ const CampaignCards = () => {
                 <Text fontWeight="bold">{name}</Text>
                 {hideFromGuildPage && (
                   <Tooltip
-                    label="This page is hidden from your guild's home page"
+                    label="Members don't see this, they can only access this page by visiting it's link directly"
                     hasArrow
                     placement="bottom"
                   >

--- a/src/components/[guild]/AccessHub/components/CampaignCards/components/CampaignCardMenu.tsx
+++ b/src/components/[guild]/AccessHub/components/CampaignCards/components/CampaignCardMenu.tsx
@@ -35,7 +35,7 @@ const CampaignCardMenu = ({ groupId }: Props) => {
     <Box position="absolute" top={2} right={2}>
       <PlatformCardMenu>
         <MenuItem icon={<PencilSimple />} onClick={onOpen}>
-          Edit page appearance
+          Customize page
         </MenuItem>
         <MenuItem
           icon={<TrashSimple />}

--- a/src/components/[guild]/AccessHub/components/CampaignCards/components/EditCampaignModal.tsx
+++ b/src/components/[guild]/AccessHub/components/CampaignCards/components/EditCampaignModal.tsx
@@ -26,7 +26,7 @@ type Props = {
 
 const EditCampaignModal = ({ groupId, onSuccess, ...modalProps }: Props) => {
   const group = useRoleGroup(groupId)
-  const { name, imageUrl, description } = group ?? {}
+  const { name, imageUrl, description, hideFromGuildPage } = group ?? {}
 
   const methods = useForm<CampaignFormType>({
     mode: "all",
@@ -34,6 +34,7 @@ const EditCampaignModal = ({ groupId, onSuccess, ...modalProps }: Props) => {
       name,
       imageUrl: imageUrl ?? "",
       description: description ?? "",
+      hideFromGuildPage,
     },
   })
   const { handleSubmit } = methods

--- a/src/components/[guild]/AccessHub/components/CampaignCards/components/EditCampaignModal.tsx
+++ b/src/components/[guild]/AccessHub/components/CampaignCards/components/EditCampaignModal.tsx
@@ -15,13 +15,14 @@ import { Modal } from "components/common/Modal"
 import usePinata from "hooks/usePinata"
 import useSubmitWithUpload from "hooks/useSubmitWithUpload"
 import { FormProvider, useForm } from "react-hook-form"
+import { Group } from "types"
 import useEditRoleGroup from "../hooks/useEditRoleGroup"
 
 type Props = {
   isOpen: boolean
   onClose: () => void
   groupId: number
-  onSuccess: () => void
+  onSuccess: (res: Group) => void
 }
 
 const EditCampaignModal = ({ groupId, onSuccess, ...modalProps }: Props) => {

--- a/src/components/[guild]/AccessHub/components/CampaignCards/hooks/useEditRoleGroup.ts
+++ b/src/components/[guild]/AccessHub/components/CampaignCards/hooks/useEditRoleGroup.ts
@@ -2,14 +2,11 @@ import useGuild from "components/[guild]/hooks/useGuild"
 import useShowErrorToast from "hooks/useShowErrorToast"
 import { SignedValidation, useSubmitWithSign } from "hooks/useSubmit"
 import useToast from "hooks/useToast"
-import { useRouter } from "next/router"
 import { Group } from "types"
 import fetcher from "utils/fetcher"
 
-const useEditRoleGroup = (groupId: number, onSuccess: () => void) => {
+const useEditRoleGroup = (groupId: number, onSuccess: (res: Group) => void) => {
   const { id, mutateGuild } = useGuild()
-  const { urlName } = useGuild()
-  const { replace } = useRouter()
 
   const toast = useToast()
   const showErrorToast = useShowErrorToast()
@@ -22,7 +19,6 @@ const useEditRoleGroup = (groupId: number, onSuccess: () => void) => {
 
   return useSubmitWithSign<Group>(editRoleGroup, {
     onSuccess: (response) => {
-      replace(`/${urlName}/${response.urlName}`)
       toast({
         status: "success",
         title: "Successfully edited page",
@@ -36,7 +32,7 @@ const useEditRoleGroup = (groupId: number, onSuccess: () => void) => {
         }),
         { revalidate: false }
       )
-      onSuccess()
+      onSuccess(response)
     },
     onError: (error) => showErrorToast(error),
   })

--- a/src/components/[guild]/CreateCampaignModal/components/CampaignForm.tsx
+++ b/src/components/[guild]/CreateCampaignModal/components/CampaignForm.tsx
@@ -72,11 +72,11 @@ const CampaignForm = ({ iconUploader }: Props) => {
         <Textarea placeholder="Optional" {...register("description")} size="lg" />
       </FormControl>
 
-      <FormControl>
+      <FormControl pt="2">
         <Switch
           {...hideFromGuildPageField}
-          title="Show on Guild page"
-          description="The page will remain public, but it won't be displayed on your guild's home page"
+          title="Show on home page"
+          description="If turned off, the page will only be accessible by visiting it's link directly"
           onChange={(e: ChangeEvent<HTMLInputElement>) =>
             hideFromGuildPageOnChange(!e.target.checked)
           }

--- a/src/components/[guild]/CreateCampaignModal/components/CampaignForm.tsx
+++ b/src/components/[guild]/CreateCampaignModal/components/CampaignForm.tsx
@@ -7,15 +7,18 @@ import {
   Textarea,
 } from "@chakra-ui/react"
 import FormErrorMessage from "components/common/FormErrorMessage"
+import Switch from "components/common/Switch"
 import IconSelector from "components/create-guild/IconSelector"
 import { GUILD_NAME_REGEX } from "components/create-guild/Name"
 import { Uploader } from "hooks/usePinata/usePinata"
-import { useFormContext } from "react-hook-form"
+import { ChangeEvent } from "react"
+import { useController, useFormContext } from "react-hook-form"
 
 export type CampaignFormType = {
   imageUrl?: string
   name: string
   description?: string
+  hideFromGuildPage?: boolean
 }
 
 type Props = {
@@ -24,9 +27,18 @@ type Props = {
 
 const CampaignForm = ({ iconUploader }: Props) => {
   const {
+    control,
     register,
     formState: { errors },
   } = useFormContext<CampaignFormType>()
+
+  const {
+    field: {
+      value: hideFromGuildPage,
+      onChange: hideFromGuildPageOnChange,
+      ...hideFromGuildPageField
+    },
+  } = useController({ control, name: "hideFromGuildPage" })
 
   return (
     <Stack spacing={6}>
@@ -57,11 +69,18 @@ const CampaignForm = ({ iconUploader }: Props) => {
 
       <FormControl>
         <FormLabel>Description</FormLabel>
-        <Textarea
-          placeholder="Optional"
-          {...register("description")}
-          size="lg"
-        ></Textarea>
+        <Textarea placeholder="Optional" {...register("description")} size="lg" />
+      </FormControl>
+
+      <FormControl>
+        <Switch
+          {...hideFromGuildPageField}
+          title="Show on Guild page"
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            hideFromGuildPageOnChange(!e.target.checked)
+          }
+          isChecked={!hideFromGuildPage}
+        />
       </FormControl>
     </Stack>
   )

--- a/src/components/[guild]/CreateCampaignModal/components/CampaignForm.tsx
+++ b/src/components/[guild]/CreateCampaignModal/components/CampaignForm.tsx
@@ -76,6 +76,7 @@ const CampaignForm = ({ iconUploader }: Props) => {
         <Switch
           {...hideFromGuildPageField}
           title="Show on Guild page"
+          description="The page will remain public, but it won't be displayed on your guild's home page"
           onChange={(e: ChangeEvent<HTMLInputElement>) =>
             hideFromGuildPageOnChange(!e.target.checked)
           }

--- a/src/components/[guild]/[group]/EditCampaignButton.tsx
+++ b/src/components/[guild]/[group]/EditCampaignButton.tsx
@@ -1,15 +1,25 @@
 import { IconButton, useDisclosure } from "@chakra-ui/react"
 import { GearSix } from "@phosphor-icons/react"
+import { useRouter } from "next/router"
+import { Group } from "types"
 import EditCampaignModal from "../AccessHub/components/CampaignCards/components/EditCampaignModal"
 import { useThemeContext } from "../ThemeContext"
+import useGuild from "../hooks/useGuild"
 import useRoleGroup from "../hooks/useRoleGroup"
 
 const EditCampaignButton = () => {
   const group = useRoleGroup()
+  const { urlName } = useGuild()
+  const { replace } = useRouter()
 
   const { textColor, buttonColorScheme } = useThemeContext()
 
   const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const onSuccess = (response: Group) => {
+    onClose()
+    replace(`/${urlName}/${response.urlName}`)
+  }
 
   return (
     <>
@@ -27,7 +37,7 @@ const EditCampaignButton = () => {
         isOpen={isOpen}
         onClose={onClose}
         groupId={group.id}
-        onSuccess={onClose}
+        onSuccess={onSuccess}
       />
     </>
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -646,6 +646,7 @@ type Group = {
   type?: string
   position?: number
   guildId: number
+  hideFromGuildPage: boolean
 }
 
 type SelectOption<T = string> = {


### PR DESCRIPTION
Admins can now hide page cards from their guild's home page with the `hideFromGuildPage` prop. These pages will be returned by our API, but we don't display them on our UI (so the goal of this feature is not to handle the actual visibility of the pages, just to clean up the access hub a bit).