### PR TITLE
chore: add activity log with filter

### DIFF
--- a/src/app/(marketing)/profile/_components/ActionLabel.tsx
+++ b/src/app/(marketing)/profile/_components/ActionLabel.tsx
@@ -1,0 +1,336 @@
+"use client"
+
+// import { Center, Icon, Text, Wrap } from "@chakra-ui/react"
+import { ArrowLeft, ArrowRight, Rocket } from "@phosphor-icons/react"
+import rewards from "rewards"
+import capitalize from "utils/capitalize"
+// import { useActivityLog } from "../../ActivityLogContext"
+// import { useActivityLogActionContext } from "../ActivityLogActionContext"
+
+// import { ClickableRoleTag } from "./ActivityLogRoleTag"
+// import { ClickableFormTag } from "./FormTag"
+// import { ClickableGuildTag } from "./GuildTag"
+// import IdentityTag from "./IdentityTag"
+// import { ClickableRewardTag } from "./RewardTag"
+// import { ClickableUserTag } from "./UserTag"
+
+import { Badge } from "@/components/ui/Badge"
+import { Skeleton } from "@/components/ui/Skeleton"
+import { useUserPublic } from "@/hooks/useUserPublic"
+import { Guild, Role } from "@guildxyz/types"
+import { ActivityLogType } from "components/[guild]/activity/ActivityLogContext"
+import { ACTION, ActivityLogAction } from "components/[guild]/activity/constants"
+import { FunctionComponent, useMemo } from "react"
+import useSWRImmutable from "swr/immutable"
+import { useProfile } from "../_hooks/useProfile"
+
+const ClickableGuildTag: FunctionComponent<{ guildId?: number }> = ({ guildId }) => {
+  const { data: guild } = useSWRImmutable<Guild>(
+    guildId === undefined ? null : `/v2/guilds/${guildId}`
+  )
+  if (!guild) {
+    return <Skeleton className="inline-block h-5 w-16 translate-y-1/4" />
+  }
+  return (
+    <Badge className="whitespace-nowrap">
+      <Rocket weight="fill" />
+      {guild.name}
+    </Badge>
+  )
+}
+
+const ClickableUserTag: FunctionComponent<{ userId: number }> = ({ userId }) => {
+  // TODO: remove this, as without `ActivityLogActionResponse` this component
+  // doesn't make sense and in the context of profile there is no reason to
+  // display user information
+  return null
+  return (
+    <Badge className="whitespace-nowrap">
+      <Rocket weight="fill" />
+      {userId}
+    </Badge>
+  )
+}
+
+const ClickableRewardTag: FunctionComponent<{
+  roleId: number
+  rolePlatformId: number
+}> = () => {
+  return null
+}
+
+const ClickableRoleTag: FunctionComponent<{
+  roleId?: number
+  guildId?: number
+}> = ({ roleId, guildId }) => {
+  const { data: role } = useSWRImmutable<Role>(
+    roleId === undefined || guildId === undefined
+      ? null
+      : `/v2/guilds/${guildId}/roles/${roleId}`
+  )
+  if (!role) {
+    return <Skeleton className="inline-block h-5 w-16 translate-y-1/4" />
+  }
+  return (
+    <Badge className="whitespace-nowrap">
+      <Rocket weight="fill" />
+      {role.name}
+    </Badge>
+  )
+}
+
+export const ActionLabel: FunctionComponent<{ activity: ActivityLogAction }> = ({
+  activity,
+}) => {
+  // const { data: activityLog, activityLogType } = useActivityLog()
+  // const { action, ids, data, parentId } = useActivityLogActionContext()
+
+  const { data: profile } = useProfile()
+  const { id: userId } = useUserPublic()
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  const isProfileOwner = useMemo(
+    () => !!profile?.userId && userId === profile.userId,
+    [userId]
+  )
+
+  const activityLogType: ActivityLogType = isProfileOwner
+    ? "all"
+    : !!userId
+      ? "user"
+      : "guild"
+
+  // const { data: activityLog, activityLogType } = useActivityLog()
+  const { action, ids, data, parentId } = activity
+  const showGuildTag = false // activityLogType === "user" || activityLogType === "all"
+  const capitalizedName = capitalize(action)
+
+  return (() => {
+    switch (action) {
+      case ACTION.CreateGuild:
+      case ACTION.LeaveGuild:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            {showGuildTag ? (
+              <ClickableGuildTag guildId={ids.guild} />
+            ) : (
+              <>
+                <span>by</span>
+                <ClickableUserTag userId={ids.user} />
+              </>
+            )}
+          </>
+        )
+      case ACTION.UpdateGuild:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            {showGuildTag ? (
+              <ClickableGuildTag guildId={ids.guild} />
+            ) : (
+              <>
+                <span> by </span>
+                <ClickableUserTag userId={ids.user} />
+              </>
+            )}
+          </>
+        )
+      case ACTION.DeleteGuild:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            <ClickableGuildTag guildId={ids.guild} />
+          </>
+        )
+      case ACTION.AddAdmin:
+      case ACTION.RemoveAdmin:
+        return (
+          <>
+            <span>{capitalizedName}:</span>
+            <ClickableUserTag userId={ids.user} />
+            {showGuildTag && <ClickableGuildTag guildId={ids.guild} />}
+          </>
+        )
+      case ACTION.CreateRole:
+      case ACTION.UpdateRole:
+      case ACTION.DeleteRole:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            <ClickableRoleTag roleId={ids.role} guildId={ids.guild} />
+            {showGuildTag ? (
+              <ClickableGuildTag guildId={ids.guild} />
+            ) : (
+              <>
+                <span>by</span>
+                <ClickableUserTag userId={ids.user} />
+              </>
+            )}
+          </>
+        )
+      case ACTION.AddReward:
+      case ACTION.RemoveReward:
+      case ACTION.UpdateReward:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            <ClickableRewardTag
+              roleId={ids.role}
+              rolePlatformId={ids.rolePlatform}
+            />
+            <span>to role</span>
+            <ClickableRoleTag roleId={ids.role} guildId={ids.guild} />
+          </>
+        )
+      case ACTION.SendReward:
+      case ACTION.RevokeReward:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            <ClickableRewardTag
+              roleId={ids.role}
+              rolePlatformId={ids.rolePlatform}
+            />
+          </>
+        )
+      case ACTION.LoseReward:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            <ClickableRewardTag
+              roleId={ids.role}
+              rolePlatformId={ids.rolePlatform}
+            />
+            {!parentId && (
+              <>
+                <ArrowLeft />
+                <ClickableUserTag userId={ids.user} />
+              </>
+            )}
+          </>
+        )
+      case ACTION.GetReward:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            <ClickableRewardTag
+              roleId={ids.role}
+              rolePlatformId={ids.rolePlatform}
+            />
+            {!parentId && (
+              <>
+                <ArrowRight />
+                <ClickableUserTag userId={ids.user} />
+              </>
+            )}
+          </>
+        )
+      case ACTION.JoinGuild:
+        return (
+          <>
+            <span>Join Guild</span>
+            {showGuildTag && <ClickableGuildTag guildId={ids.guild} />}
+            {activityLogType !== "user" && <ClickableUserTag userId={ids.user} />}
+          </>
+        )
+      case ACTION.ClickJoinOnPlatform:
+        return (
+          <>
+            <span>{`Join Guild through ${rewards[data.platformName].name}`}</span>
+            {showGuildTag ? (
+              <ClickableGuildTag guildId={ids.guild} />
+            ) : (
+              <ClickableUserTag userId={ids.user} />
+            )}
+          </>
+        )
+      case ACTION.UserStatusUpdate:
+      case ACTION.OptOut:
+      case ACTION.OptIn:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            {showGuildTag ? (
+              <ClickableGuildTag guildId={ids.guild} />
+            ) : (
+              <ClickableUserTag userId={ids.user} />
+            )}
+          </>
+        )
+      case ACTION.GetRole:
+      case ACTION.LoseRole:
+        // const parentaction = activityLog?.entries?.find(
+        //   (log) => log.id === parentId
+        // )?.action
+        // const isChildOfUserStatusUpdate = [
+        //   ACTION.UserStatusUpdate,
+        //   ACTION.JoinGuild,
+        //   ACTION.ClickJoinOnPlatform,
+        //   ACTION.LeaveGuild,
+        // ].includes(parentaction)
+
+        return (
+          <>
+            <span>{capitalizedName}:</span>
+            <ClickableRoleTag roleId={ids.role} guildId={ids.guild} />
+          </>
+        )
+      case ACTION.AddRequirement:
+      case ACTION.UpdateRequirement:
+      case ACTION.RemoveRequirement:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            {!parentId && <ClickableRoleTag roleId={ids.role} guildId={ids.guild} />}
+            {showGuildTag ? (
+              <ClickableGuildTag guildId={ids.guild} />
+            ) : (
+              <ClickableUserTag userId={ids.user} />
+            )}
+          </>
+        )
+
+      // case ACTION.CreateForm:
+      // case ACTION.UpdateForm:
+      // case ACTION.DeleteForm:
+      // case ACTION.SubmitForm:
+      //   return (
+      //     <>
+      //       <span>{capitalizedName}</span>
+      //       {activityLogType !== "guild" && (
+      //         <ClickableGuildTag guildId={ids.guild} />
+      //       )}
+      //
+      //       <ClickableFormTag
+      //         formId={ids.form}
+      //         guildId={ids.guild}
+      //         userId={ids.user}
+      //       />
+      //       {activityLogType !== "user" && <ClickableUserTag userId={ids.user} />}
+      //     </>
+      //   )
+
+      // case ACTION.ConnectIdentity:
+      // case ACTION.DisconnectIdentity:
+      //   return (
+      //     <>
+      //       <span>{capitalizedName}</span>
+      //       <IdentityTag platformName={data.platformName} username={data.username} />
+      //       {activityLogType != "user" && <ClickableUserTag userId={ids.user} />}
+      //     </>
+      //   )
+
+      default:
+        return (
+          <>
+            <span>{capitalizedName}</span>
+            {ids.role ? (
+              <ClickableRoleTag roleId={ids.role} guildId={ids.guild} />
+            ) : ids.user ? (
+              <ClickableUserTag userId={ids.user} />
+            ) : null}
+          </>
+        )
+    }
+  })()
+}

--- a/src/app/(marketing)/profile/_components/ActivityCard.tsx
+++ b/src/app/(marketing)/profile/_components/ActivityCard.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/Avatar"
+import { Card } from "@/components/ui/Card"
+import { Guild } from "@guildxyz/types"
+import { ActivityLogAction } from "components/[guild]/activity/constants"
+import ClientOnly from "components/common/ClientOnly"
+import useSWRImmutable from "swr/immutable"
+import formatRelativeTimeFromNow from "utils/formatRelativeTimeFromNow"
+import { ActionLabel } from "./ActionLabel"
+
+export const ActivityCard = ({ activity }: { activity: ActivityLogAction }) => {
+  const { data: guild } = useSWRImmutable<Guild>(
+    activity.ids.guild ? `/v2/guilds/${activity.ids.guild}` : null
+  )
+
+  return (
+    <Card className="flex">
+      {guild && (
+        <div
+          className="flex h-full w-9 items-center justify-center border-border border-r-2 bg-accent"
+          style={{ background: guild.theme.color }}
+        >
+          <div className="-rotate-90 flex items-center gap-1">
+            <Avatar size="xs">
+              <AvatarImage
+                width={24}
+                height={24}
+                src={guild.imageUrl}
+                alt="guild avatar"
+              />
+              <AvatarFallback />
+            </Avatar>
+            <span className="max-w-14 truncate font-bold font-display text-sm">
+              {guild.name}
+            </span>
+          </div>
+        </div>
+      )}
+      <div className="px-5 py-6">
+        <h3 className="space-x-1.5 font-bold">
+          <ActionLabel activity={activity} />
+          {/*Acquire the{" "}
+          <Badge className="whitespace-nowrap">
+            <Rocket weight="fill" className="mr-1" />
+            Enter Farcaster
+          </Badge>{" "}
+          role*/}
+        </h3>
+        <div className="mt-1.5 flex flex-wrap items-center gap-2">
+          <ClientOnly>
+            <p className="text-muted-foreground">
+              {formatRelativeTimeFromNow(Date.now() - parseInt(activity.timestamp))}{" "}
+              ago
+            </p>
+          </ClientOnly>
+          {/*<Circle
+            className="hidden size-1.5 text-muted-foreground sm:block"
+            weight="fill"
+          />*/}
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/app/(marketing)/profile/_components/Profile.tsx
+++ b/src/app/(marketing)/profile/_components/Profile.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { CheckMark } from "@/components/CheckMark"
+import { useWeb3ConnectionManager } from "@/components/Web3ConnectionManager/hooks/useWeb3ConnectionManager"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/Avatar"
 import { AvatarGroup } from "@/components/ui/AvatarGroup"
 import { Card } from "@/components/ui/Card"
@@ -23,6 +24,7 @@ export const Profile = () => {
   const { data: profile } = useProfile()
   const { data: contributions } = useContributions()
   const { data: referredUsers } = useReferredUsers()
+  const { isWeb3Connected } = useWeb3ConnectionManager()
 
   if (!profile || !contributions || !referredUsers) return <ProfileSkeleton />
 
@@ -97,13 +99,15 @@ export const Profile = () => {
           <ContributionCard contribution={contribution} key={contribution.id} />
         ))}
       </div>
-      <div className="mt-8">
-        <SectionTitle className="mb-3">Recent activity</SectionTitle>
-        <RecentActivity />
-        <p className="mt-2 font-semibold text-muted-foreground">
-          &hellip; only last 20 actions are shown
-        </p>
-      </div>
+      {isWeb3Connected && (
+        <div className="mt-8">
+          <SectionTitle className="mb-3">Recent activity</SectionTitle>
+          <RecentActivity />
+          <p className="mt-2 font-semibold text-muted-foreground">
+            &hellip; only last 20 actions are shown
+          </p>
+        </div>
+      )}
     </>
   )
 }


### PR DESCRIPTION
### Objective

Use the `/v2/audit-log` endpoint with `username` search param to fill the recent activity section of the profile page, group activites and associate logical actions for each individual group.

#### Implementation details

Some code were adapted from existing guild page activity log, however in the context of profile many actions wouldn't make sense so they were mostly left out and rewritten. Moreover the profile doesn't require as sophisticated filtering options, further motivating the rework.
