### PR TITLE
feat: add reorder to requirements [GUILD-3711]

### DIFF
--- a/src/components/create-guild/Requirements/EditRequirements.tsx
+++ b/src/components/create-guild/Requirements/EditRequirements.tsx
@@ -1,15 +1,19 @@
-import { Collapse, Stack } from "@chakra-ui/react"
+import { useDisclosure } from "@/hooks/useDisclosure"
+import { Button, Collapse, HStack, Stack } from "@chakra-ui/react"
+import { ListNumbers } from "@phosphor-icons/react"
 import LogicDivider from "components/[guild]/LogicDivider"
 import useRequirements from "components/[guild]/hooks/useRequirements"
 import CardMotionWrapper from "components/common/CardMotionWrapper"
 import { SectionTitle } from "components/common/Section"
 import { AnimatePresence } from "framer-motion"
+import { useRef } from "react"
 import { useWatch } from "react-hook-form"
 import FreeRequirement from "requirements/Free/FreeRequirement"
 import mapRequirement from "utils/mapRequirement"
 import AddRequirement from "./components/AddRequirement"
 import ExistingRequirementEditableCard from "./components/ExistingRequirementEditableCard"
 import LogicFormControl from "./components/LogicFormControl"
+import OrderRequirementsModal from "./components/OrderRequirementsModal"
 import RequirementBaseCard from "./components/RequirementBaseCard"
 
 type Props = { roleId: number }
@@ -21,42 +25,69 @@ const EditRequirements = ({ roleId }: Props) => {
 
   const mappedRequirements = requirements?.map(mapRequirement)
 
+  const {
+    isOpen: isOrderModalOpen,
+    onOpen: onOrderModalOpen,
+    onClose: onOrderModalClose,
+  } = useDisclosure()
+  const orderButtonRef = useRef(null)
+
   return (
-    <Stack spacing="5" w="full">
-      <SectionTitle title="Requirements" />
+    <>
+      <Stack spacing="5" w="full">
+        <HStack justifyContent="space-between">
+          <SectionTitle title="Requirements" />
+          <Button
+            size={"sm"}
+            ref={orderButtonRef}
+            onClick={onOrderModalOpen}
+            leftIcon={<ListNumbers />}
+            variant={"ghost"}
+          >
+            Reorder requirements
+          </Button>
+        </HStack>
 
-      {/* negative margin with padding so LogicFormControl's input focus states doesn't get cut off */}
-      <Collapse in={!freeEntry} style={{ margin: "-2px", padding: "2px" }}>
-        <LogicFormControl requirements={mappedRequirements} />
-      </Collapse>
+        {/* negative margin with padding so LogicFormControl's input focus states doesn't get cut off */}
+        <Collapse in={!freeEntry} style={{ margin: "-2px", padding: "2px" }}>
+          <LogicFormControl requirements={mappedRequirements} />
+        </Collapse>
 
-      <Stack spacing={0}>
-        <AnimatePresence>
-          {freeEntry ? (
-            <CardMotionWrapper key="free-entry">
-              <RequirementBaseCard>
-                <FreeRequirement />
-              </RequirementBaseCard>
-              <LogicDivider logic="OR" />
-            </CardMotionWrapper>
-          ) : (
-            mappedRequirements.map((requirement) => (
-              <CardMotionWrapper key={requirement.id}>
-                <ExistingRequirementEditableCard
-                  requirement={requirement}
-                  isEditDisabled={
-                    requirement.type === "PAYMENT" ||
-                    requirement.type === "GUILD_SNAPSHOT"
-                  }
-                />
-                <LogicDivider logic={logic ?? "AND"} />
+        <Stack spacing={0}>
+          <AnimatePresence>
+            {freeEntry ? (
+              <CardMotionWrapper key="free-entry">
+                <RequirementBaseCard>
+                  <FreeRequirement />
+                </RequirementBaseCard>
+                <LogicDivider logic="OR" />
               </CardMotionWrapper>
-            ))
-          )}
-          <AddRequirement />
-        </AnimatePresence>
+            ) : (
+              mappedRequirements.map((requirement) => (
+                <CardMotionWrapper key={requirement.id}>
+                  <ExistingRequirementEditableCard
+                    requirement={requirement}
+                    isEditDisabled={
+                      requirement.type === "PAYMENT" ||
+                      requirement.type === "GUILD_SNAPSHOT"
+                    }
+                  />
+                  <LogicDivider logic={logic ?? "AND"} />
+                </CardMotionWrapper>
+              ))
+            )}
+            <AddRequirement />
+          </AnimatePresence>
+        </Stack>
       </Stack>
-    </Stack>
+      <OrderRequirementsModal
+        roleId={roleId}
+        requirements={mappedRequirements}
+        isOpen={isOrderModalOpen}
+        onClose={onOrderModalClose}
+        finalFocusRef={orderButtonRef}
+      />
+    </>
   )
 }
 

--- a/src/components/create-guild/Requirements/components/DraggableRequirementCard.tsx
+++ b/src/components/create-guild/Requirements/components/DraggableRequirementCard.tsx
@@ -1,0 +1,34 @@
+import { HStack, Icon, Spacer } from "@chakra-ui/react"
+import { DotsSixVertical } from "@phosphor-icons/react"
+import { RequirementProvider } from "components/[guild]/Requirements/components/RequirementContext"
+import { REQUIREMENT_DISPLAY_COMPONENTS } from "requirements/requirementDisplayComponents"
+import { Requirement } from "types"
+import RequirementBaseCard from "./RequirementBaseCard"
+
+type Props = {
+  requirement: Requirement
+}
+
+export const DraggableRequirementCard = ({ requirement }: Props) => {
+  if (!requirement) return null
+  const RequirementComponent = REQUIREMENT_DISPLAY_COMPONENTS[requirement.type]
+
+  const showViewOriginal =
+    requirement.data?.customName || requirement.data?.customImage
+
+  return (
+    <HStack spacing={4} cursor="grab" mb="3">
+      <HStack spacing={1} userSelect="none">
+        <RequirementBaseCard>
+          <RequirementProvider requirement={requirement}>
+            <RequirementComponent
+              showViewOriginal={showViewOriginal}
+              rightElement={<Icon as={DotsSixVertical} />}
+            />
+          </RequirementProvider>
+        </RequirementBaseCard>
+      </HStack>
+      <Spacer />
+    </HStack>
+  )
+}

--- a/src/components/create-guild/Requirements/components/OrderRequirementsModal.tsx
+++ b/src/components/create-guild/Requirements/components/OrderRequirementsModal.tsx
@@ -1,0 +1,178 @@
+import {
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react"
+import Button from "components/common/Button"
+import DiscardAlert from "components/common/DiscardAlert"
+import { Modal } from "components/common/Modal"
+import { Reorder } from "framer-motion"
+import { MutableRefObject, useMemo, useState } from "react"
+import { Requirement } from "types"
+import { useReorderRequirements } from "../hooks/useReorderRequirements"
+import { DraggableRequirementCard } from "./DraggableRequirementCard"
+
+const OrderRequirementsModal = ({
+  isOpen,
+  onClose,
+  finalFocusRef,
+  requirements,
+  roleId,
+}: {
+  isOpen: boolean
+  onClose: () => void
+  finalFocusRef: MutableRefObject<null>
+  requirements: Requirement[]
+  roleId: number
+}): JSX.Element => {
+  // const { requirements } = useGuild()
+  // const group = useRequirementGroup()
+  const relevantRequirements = requirements
+  // group
+  // ? requirements.filter((requirement) => requirement.groupId === group.id)
+  // : requirements.filter((requirement) => !requirement.groupId)
+
+  const {
+    isOpen: isAlertOpen,
+    onOpen: onAlertOpen,
+    onClose: onAlertClose,
+  } = useDisclosure()
+
+  // temporary, will order requirements already in the SQL query in the future
+  const sortedRequirements = useMemo(() => {
+    if (
+      relevantRequirements?.every((requirement) => requirement.position === null)
+    ) {
+      const byMembers = relevantRequirements?.sort(
+        (requirement1, requirement2) =>
+          requirement2.createdAt.valueOf() - requirement1.createdAt.valueOf()
+      )
+      return byMembers
+    }
+
+    return (
+      relevantRequirements?.sort((requirement1, requirement2) => {
+        if (requirement1.position === null) return 1
+        if (requirement2.position === null) return -1
+        return requirement1.position - requirement2.position
+      }) ?? []
+    )
+  }, [relevantRequirements])
+
+  const publicAndSecretRequirements = sortedRequirements.filter(
+    (requirement) => requirement.visibility !== "HIDDEN"
+  )
+
+  const defaultRequirementIdsOrder = publicAndSecretRequirements?.map(
+    (requirement) => requirement.id
+  )
+  const [requirementIdsOrder, setRequirementIdsOrder] = useState(
+    defaultRequirementIdsOrder
+  )
+
+  /**
+   * Using JSON.stringify to compare the values, not the object identity (so it works
+   * as expected after a successful save too)
+   */
+  const isDirty =
+    JSON.stringify(defaultRequirementIdsOrder) !==
+    JSON.stringify(requirementIdsOrder)
+
+  const { isLoading, onSubmit } = useReorderRequirements(onClose, roleId)
+
+  const handleSubmit = () => {
+    const changedRequirements = requirementIdsOrder
+      .map((requirementId, i) => ({
+        id: requirementId,
+        position: i,
+      }))
+      .filter(({ id: requirementId, position }) =>
+        (relevantRequirements ?? []).some(
+          (prevRequirement) =>
+            prevRequirement.id === requirementId &&
+            prevRequirement.position !== position
+        )
+      )
+
+    console.log(changedRequirements)
+    return onSubmit(changedRequirements)
+  }
+
+  const onCloseAndClear = () => {
+    setRequirementIdsOrder(defaultRequirementIdsOrder)
+    onClose()
+    onAlertClose()
+  }
+
+  return (
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={isDirty ? onAlertOpen : onClose}
+        colorScheme="dark"
+        finalFocusRef={finalFocusRef}
+        scrollBehavior="inside"
+        size="lg"
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Requirement order</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody className="custom-scrollbar">
+            <Reorder.Group
+              axis="y"
+              values={requirementIdsOrder}
+              onReorder={setRequirementIdsOrder}
+            >
+              {relevantRequirements?.length ? (
+                requirementIdsOrder?.map((requirementId) => (
+                  <Reorder.Item
+                    key={requirementId}
+                    value={requirementId}
+                    style={{ position: "relative" }} // needed for the auto-applied zIndex to work
+                  >
+                    <DraggableRequirementCard
+                      requirement={
+                        relevantRequirements?.find(
+                          (requirement) => requirement.id === requirementId
+                        )!
+                      }
+                    />
+                  </Reorder.Item>
+                ))
+              ) : (
+                <Text>No requirements yet</Text>
+              )}
+            </Reorder.Group>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button variant="outline" mr={3} onClick={onCloseAndClear}>
+              Cancel
+            </Button>
+            <Button
+              isLoading={isLoading}
+              onClick={handleSubmit}
+              colorScheme="green"
+              isDisabled={!isDirty}
+            >
+              Save
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+      <DiscardAlert
+        isOpen={isAlertOpen}
+        onClose={onAlertClose}
+        onDiscard={onCloseAndClear}
+      />
+    </>
+  )
+}
+
+export default OrderRequirementsModal

--- a/src/components/create-guild/Requirements/components/OrderRequirementsModal.tsx
+++ b/src/components/create-guild/Requirements/components/OrderRequirementsModal.tsx
@@ -30,12 +30,7 @@ const OrderRequirementsModal = ({
   requirements: Requirement[]
   roleId: number
 }): JSX.Element => {
-  // const { requirements } = useGuild()
-  // const group = useRequirementGroup()
   const relevantRequirements = requirements
-  // group
-  // ? requirements.filter((requirement) => requirement.groupId === group.id)
-  // : requirements.filter((requirement) => !requirement.groupId)
 
   const {
     isOpen: isAlertOpen,

--- a/src/components/create-guild/Requirements/hooks/useReorderRequirements.ts
+++ b/src/components/create-guild/Requirements/hooks/useReorderRequirements.ts
@@ -1,0 +1,59 @@
+import useGuild from "components/[guild]/hooks/useGuild"
+import { useFetcherWithSign } from "hooks/useFetcherWithSign"
+import useShowErrorToast from "hooks/useShowErrorToast"
+import useSubmit from "hooks/useSubmit/useSubmit"
+import useToast from "hooks/useToast"
+
+export const useReorderRequirements = (onClose: () => void, roleId: number) => {
+  const { id: guildId, mutateGuild } = useGuild()
+  const toast = useToast()
+  const showErrorToast = useShowErrorToast()
+  const fetcherWithSign = useFetcherWithSign()
+
+  const submit = (requirementOrdering: Array<{ id: number; position: number }>) =>
+    Promise.all(
+      requirementOrdering.map(({ id: requirementId, position }) =>
+        fetcherWithSign([
+          `/v2/guilds/${guildId}/roles/${roleId}/requirements/${requirementId}`,
+          { method: "PUT", body: { position } },
+        ])
+      )
+    )
+
+  const { onSubmit, isLoading } = useSubmit(submit, {
+    onSuccess: (newRequirements) => {
+      toast({
+        status: "success",
+        title: "Successfully edited requirement order",
+      })
+      onClose()
+      mutateGuild(
+        (oldData) =>
+          oldData && {
+            ...oldData,
+            roles: oldData.roles.map((role) =>
+              role.id === roleId
+                ? {
+                    ...role,
+                    requirements: (role.requirements ?? []).map(
+                      (prevRequirement) => ({
+                        ...prevRequirement,
+                        ...(newRequirements ?? []).find(
+                          (newRequirement) =>
+                            newRequirement.id === prevRequirement.id
+                        ),
+                      })
+                    ),
+                  }
+                : role
+            ),
+          },
+        {
+          revalidate: false,
+        }
+      )
+    },
+    onError: (error) => showErrorToast(error),
+  })
+  return { onSubmit, isLoading }
+}


### PR DESCRIPTION
### Objective

Make reordering possible in the `EditRequirements` section of `EditRole` drawer, similar to how role reordering is currently implemented.

Adapt code from `OrderRolesModal` and it's submodules.

### Implementation details

The role order after reordering is sent as `PUT` through the `/v2/guilds/{{guildId}}/roles/{{roleId}}` endpoint with an additional `position` value in the payload. The same is implemented for requirement, but with the `/v2/guilds/{{guildId}}/roles/{{roleId}}/requirements/{{requirementId}}` endpoint to change ordering.
