### PR TITLE
fix(useCreateRequirement(s)): mutate `requiredPlatforms`

### DIFF
--- a/src/rewards/Discord/data.ts
+++ b/src/rewards/Discord/data.ts
@@ -10,4 +10,5 @@ export const discordData = {
   autoRewardSetup: false,
   isPlatform: true,
   asRewardRestriction: PlatformAsRewardRestrictions.MULTIPLE_ROLES,
+  requiredForRequirements: true,
 } satisfies RewardData

--- a/src/rewards/Email/data.ts
+++ b/src/rewards/Email/data.ts
@@ -9,4 +9,5 @@ export const emailData = {
   autoRewardSetup: false,
   isPlatform: true,
   asRewardRestriction: PlatformAsRewardRestrictions.NOT_APPLICABLE,
+  requiredForRequirements: true,
 } as const satisfies RewardData

--- a/src/rewards/Farcaster/data.ts
+++ b/src/rewards/Farcaster/data.ts
@@ -10,4 +10,5 @@ export const farcasterData = {
   autoRewardSetup: false,
   isPlatform: true,
   asRewardRestriction: PlatformAsRewardRestrictions.NOT_APPLICABLE,
+  requiredForRequirements: true,
 } satisfies RewardData

--- a/src/rewards/Github/data.ts
+++ b/src/rewards/Github/data.ts
@@ -10,4 +10,5 @@ export const githubData = {
   autoRewardSetup: false,
   isPlatform: true,
   asRewardRestriction: PlatformAsRewardRestrictions.SINGLE_ROLE,
+  requiredForRequirements: true,
 } as const satisfies RewardData

--- a/src/rewards/Google/data.ts
+++ b/src/rewards/Google/data.ts
@@ -10,4 +10,5 @@ export const googleData = {
   autoRewardSetup: false,
   isPlatform: true,
   asRewardRestriction: PlatformAsRewardRestrictions.SINGLE_ROLE,
+  requiredForRequirements: true,
 } satisfies RewardData

--- a/src/rewards/PolygonID/data.ts
+++ b/src/rewards/PolygonID/data.ts
@@ -10,4 +10,5 @@ export const polygonIdData = {
   autoRewardSetup: true,
   isPlatform: false,
   asRewardRestriction: PlatformAsRewardRestrictions.MULTIPLE_ROLES,
+  requiredForRequirements: true,
 } as const satisfies RewardData

--- a/src/rewards/Telegram/data.ts
+++ b/src/rewards/Telegram/data.ts
@@ -10,4 +10,5 @@ export const telegramData = {
   autoRewardSetup: false,
   isPlatform: true,
   asRewardRestriction: PlatformAsRewardRestrictions.SINGLE_ROLE,
+  requiredForRequirements: true,
 } as const satisfies RewardData

--- a/src/rewards/Twitter/data.ts
+++ b/src/rewards/Twitter/data.ts
@@ -9,6 +9,7 @@ export const twitterV1Data = {
   autoRewardSetup: false,
   isPlatform: true,
   asRewardRestriction: PlatformAsRewardRestrictions.NOT_APPLICABLE,
+  requiredForRequirements: true,
 } as const satisfies RewardData
 
 export const twitterData = {
@@ -20,4 +21,5 @@ export const twitterData = {
   autoRewardSetup: false,
   isPlatform: false,
   asRewardRestriction: PlatformAsRewardRestrictions.NOT_APPLICABLE,
+  requiredForRequirements: true,
 } as const satisfies RewardData

--- a/src/rewards/index.ts
+++ b/src/rewards/index.ts
@@ -36,6 +36,10 @@ const rewards: Rewards = {
   FARCASTER: farcasterData,
 } as const
 
+export const JOINABLE_REQUIREMENT_PLATFORMS = Object.entries(rewards)
+  .filter(([, reward]) => reward.requiredForRequirements)
+  .map(([rewardName]) => rewardName)
+
 export default rewards
 
 export * from "./constants"

--- a/src/rewards/index.ts
+++ b/src/rewards/index.ts
@@ -14,6 +14,7 @@ import { telegramData } from "rewards/Telegram/data"
 import { tokenData } from "rewards/Token/data"
 import { twitterData, twitterV1Data } from "rewards/Twitter/data"
 import { uniqueTextData } from "rewards/UniqueText/data"
+import { PlatformName } from "types"
 import { Rewards } from "./types"
 
 const rewards: Rewards = {
@@ -38,7 +39,7 @@ const rewards: Rewards = {
 
 export const JOINABLE_REQUIREMENT_PLATFORMS = Object.entries(rewards)
   .filter(([, reward]) => reward.requiredForRequirements)
-  .map(([rewardName]) => rewardName)
+  .map(([rewardName]) => rewardName) as PlatformName[]
 
 export default rewards
 

--- a/src/rewards/types.ts
+++ b/src/rewards/types.ts
@@ -45,6 +45,10 @@ export type RewardData = {
   autoRewardSetup: boolean
   isPlatform: boolean
   asRewardRestriction: PlatformAsRewardRestrictions
+  /**
+   * True when the guildPlatform can be included in the `requiredPlatforms` array
+   */
+  requiredForRequirements?: boolean
 }
 
 export type RewardComponentsData = {


### PR DESCRIPTION
When an admin added a new requirement which required a platform connection (e.g. Twitter, Farcaster, Email, etc.), and then opened the join modal (with another account, without refreshing the page), the newly added `requiredPlatform`s weren't included in the `/guild-page` SWR cache. This PR aims to fix this issue.

My first idea was to just add an if statement inside the `useCreateRequirement` and `useCreateRequirements` hooks, but I'm 100% sure I'd forgot to update these conditions when we add a new platform type to guild, so that's why I went with this solution instead. 