### PR TITLE
improve ui `Button` loading state

### DIFF
--- a/src/v2/components/ui/Button.stories.ts
+++ b/src/v2/components/ui/Button.stories.ts
@@ -17,6 +17,7 @@ export const Solid: Story = {
     size: "md",
     variant: "solid",
     colorScheme: "primary",
+    loadingText: undefined,
     isLoading: false,
     disabled: false,
   },
@@ -25,6 +26,10 @@ export const Solid: Story = {
       type: "string",
       control: "select",
       options: ["xs", "sm", "md", "lg", "xl"] satisfies ButtonProps["size"][],
+    },
+    loadingText: {
+      type: "string",
+      control: "text",
     },
     colorScheme: {
       type: "string",

--- a/src/v2/components/ui/Button.stories.tsx
+++ b/src/v2/components/ui/Button.stories.tsx
@@ -1,5 +1,5 @@
+import { Book } from "@phosphor-icons/react"
 import type { Meta, StoryObj } from "@storybook/react"
-
 import { Button, ButtonProps } from "./Button"
 
 const meta: Meta<typeof Button> = {
@@ -89,5 +89,58 @@ export const Subtle: Story = {
   },
   argTypes: {
     ...Solid.argTypes,
+  },
+}
+
+export const WithIcon: Story = {
+  args: {
+    children: (
+      <>
+        <Book />
+        hello
+      </>
+    ),
+    size: "md",
+    variant: "solid",
+    colorScheme: "primary",
+    loadingText: undefined,
+    isLoading: false,
+    disabled: false,
+  },
+  argTypes: {
+    size: {
+      type: "string",
+      control: "select",
+      options: ["xs", "sm", "md", "lg", "xl"] satisfies ButtonProps["size"][],
+    },
+    loadingText: {
+      type: "string",
+      control: "text",
+    },
+    colorScheme: {
+      type: "string",
+      control: "select",
+      options: [
+        "primary",
+        "secondary",
+        "info",
+        "destructive",
+        "success",
+      ] satisfies ButtonProps["colorScheme"][],
+    },
+    variant: {
+      control: {
+        disable: true,
+      },
+    },
+    disabled: {
+      type: "boolean",
+      control: "boolean",
+    },
+    asChild: {
+      control: {
+        disable: true,
+      },
+    },
   },
 }

--- a/src/v2/components/ui/Button.tsx
+++ b/src/v2/components/ui/Button.tsx
@@ -88,9 +88,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
         disabled={isLoading || disabled}
       >
-        {isLoading ? <CircleNotch weight="bold" className="animate-spin" /> : null}
-
-        {isLoading ? (
+        {isLoading && <CircleNotch weight="bold" className="animate-spin" />}
+        {isLoading && loadingText ? (
           <span>{loadingText}</span>
         ) : typeof children === "string" ? (
           <span>{children}</span>

--- a/src/v2/components/ui/Button.tsx
+++ b/src/v2/components/ui/Button.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/utils"
 import { CircleNotch } from "@phosphor-icons/react/dist/ssr"
 import { Slot } from "@radix-ui/react-slot"
 import { type VariantProps, cva } from "class-variance-authority"
-import { ButtonHTMLAttributes, forwardRef } from "react"
+import { ButtonHTMLAttributes, ReactNode, forwardRef } from "react"
 
 const buttonVariants = cva(
   "font-semibold inline-flex items-center justify-center whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-4 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 rounded-xl text-base text-ellipsis overflow-hidden gap-1.5 cursor-pointer",
@@ -63,6 +63,19 @@ export interface ButtonProps
   asChild?: boolean
 }
 
+const extractString = (node: ReactNode): string => {
+  if (typeof node === "string") return node
+  // @ts-ignore WARNING: hacky solution, untyped properties
+  const children = node?.props?.children
+  if (children) {
+    if (Array.isArray(children)) {
+      return children.map((child: ReactNode) => extractString(child)).join("")
+    }
+    return extractString(children)
+  }
+  return ""
+}
+
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
@@ -88,11 +101,11 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
         disabled={isLoading || disabled}
       >
-        {isLoading && <CircleNotch weight="bold" className="animate-spin" />}
-        {isLoading && loadingText ? (
-          <span>{loadingText}</span>
-        ) : typeof children === "string" ? (
-          <span>{children}</span>
+        {isLoading ? (
+          <>
+            <CircleNotch weight="bold" className="animate-spin" />
+            {extractString(children)}
+          </>
         ) : (
           children
         )}


### PR DESCRIPTION
### Motivation

Currently our loading state without loading text shows an empty spinner with an odd space on the right (due to flexbox gap on `Button`).

### Resolution

If `loadingText` is missing, we should fallback to default `children` prop.

- Added `loadingText` to storybook as a bonus! :star:
