### PR TITLE
Add operated guilds and improve `/profile`

### DIFF
--- a/src/app/(marketing)/profile/[username]/page.tsx
+++ b/src/app/(marketing)/profile/[username]/page.tsx
@@ -174,6 +174,9 @@ const fetchPublicProfileData = async ({
     },
   })
 
+  const operatedGuildsRequest = new URL(`/v2/guilds?username=${username}`, api)
+  const operatedGuilds = await ssrFetcher<Guild[]>(operatedGuildsRequest)
+
   return {
     profile,
     fallback: Object.fromEntries(
@@ -187,6 +190,10 @@ const fetchPublicProfileData = async ({
         [
           experienceCountRequest.pathname + experienceCountRequest.search,
           experienceCount,
+        ],
+        [
+          operatedGuildsRequest.pathname + operatedGuildsRequest.search,
+          operatedGuilds,
         ],
         ...collectionsZipped,
         ...guildsZipped,

--- a/src/app/(marketing)/profile/_components/OperatedGuilds.tsx
+++ b/src/app/(marketing)/profile/_components/OperatedGuilds.tsx
@@ -4,10 +4,8 @@ import { Card } from "@/components/ui/Card"
 import { Skeleton } from "@/components/ui/Skeleton"
 import { Icon } from "@phosphor-icons/react"
 import {
-  ArrowFatUp,
   Calendar,
   FolderSimpleUser,
-  ShootingStar,
   Star,
   User,
 } from "@phosphor-icons/react/dist/ssr"
@@ -79,10 +77,6 @@ export const OperatedGuild = ({ guildBase }: { guildBase: GuildBase }) => {
           </EmphasizedData>{" "}
           members
         </OperatedGuildDetail>
-        <OperatedGuildDetail Icon={ArrowFatUp}>
-          Avg level of members:
-          <EmphasizedData>___</EmphasizedData>
-        </OperatedGuildDetail>
         <OperatedGuildDetail Icon={FolderSimpleUser}>
           <EmphasizedData>{guildBase.rolesCount}</EmphasizedData>
           roles
@@ -90,11 +84,6 @@ export const OperatedGuild = ({ guildBase }: { guildBase: GuildBase }) => {
         <OperatedGuildDetail Icon={Star}>
           <EmphasizedData>{rewardCount}</EmphasizedData>
           rewards in total
-        </OperatedGuildDetail>
-        <OperatedGuildDetail Icon={ShootingStar}>
-          In the top
-          <EmphasizedData>__%</EmphasizedData>
-          of guilds
         </OperatedGuildDetail>
         {createdAt && (
           <OperatedGuildDetail Icon={Calendar}>

--- a/src/app/(marketing)/profile/_components/OperatedGuilds.tsx
+++ b/src/app/(marketing)/profile/_components/OperatedGuilds.tsx
@@ -1,0 +1,123 @@
+import { CheckMark } from "@/components/CheckMark"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/Avatar"
+import { Card } from "@/components/ui/Card"
+import { Skeleton } from "@/components/ui/Skeleton"
+import { Icon } from "@phosphor-icons/react"
+import {
+  ArrowFatUp,
+  Calendar,
+  FolderSimpleUser,
+  ShootingStar,
+  Star,
+  User,
+} from "@phosphor-icons/react/dist/ssr"
+import useGuild from "components/[guild]/hooks/useGuild"
+import Image from "next/image"
+import { PropsWithChildren } from "react"
+import { GuildBase } from "types"
+import formatRelativeTimeFromNow from "utils/formatRelativeTimeFromNow"
+
+export const OperatedGuild = ({ guildBase }: { guildBase: GuildBase }) => {
+  const guild = useGuild(guildBase.id)
+  const createdAt =
+    guild.createdAt &&
+    formatRelativeTimeFromNow(
+      Date.now().valueOf() - new Date(guild.createdAt).valueOf()
+    )
+  const rewardCount =
+    guild.guildPlatforms &&
+    guild.guildPlatforms.length +
+      (guild?.roles?.reduce((acc, val) => acc + val?.rolePlatforms.length, 0) || 0)
+
+  return (
+    <Card className="flex flex-col bg-gray-50 md:flex-row dark:bg-card">
+      <div className="relative w-full border-border-muted p-6 max-md:border-b md:w-1/3 md:border-r">
+        <div className="absolute inset-0 bg-black" />
+        {guild.theme?.backgroundImage ? (
+          <Image
+            className="absolute inset-0 size-full object-cover opacity-30"
+            src={guild.theme.backgroundImage}
+            alt="guild banner"
+            width={419}
+            height={233}
+          />
+        ) : (
+          guild.theme?.color && (
+            <div
+              className="absolute inset-0 size-full object-cover opacity-30"
+              style={{ background: guild.theme.color }}
+            />
+          )
+        )}
+        <div className="relative flex h-full flex-col items-center justify-center gap-3">
+          <Avatar className="size-20 lg:size-24">
+            <AvatarImage
+              src={guildBase.imageUrl}
+              width={118}
+              height={118}
+              alt="guild image"
+            />
+            <AvatarFallback>
+              <Skeleton className="size-full" />
+            </AvatarFallback>
+          </Avatar>
+          <h3 className="text-center font-bold font-display text-lg text-white lg:text-xl">
+            {guildBase.name}
+            {guildBase.tags.includes("VERIFIED") && (
+              <CheckMark className="ml-2 inline-block size-6 align-text-top" />
+            )}
+          </h3>
+        </div>
+      </div>
+      <div className="grid grow justify-stretch gap-2 p-5 sm:grid-cols-2">
+        <OperatedGuildDetail Icon={User}>
+          <EmphasizedData>
+            {new Intl.NumberFormat("en-US", {
+              notation: "compact",
+              maximumFractionDigits: 2,
+            }).format(guildBase.memberCount)}
+          </EmphasizedData>{" "}
+          members
+        </OperatedGuildDetail>
+        <OperatedGuildDetail Icon={ArrowFatUp}>
+          Avg level of members:
+          <EmphasizedData>___</EmphasizedData>
+        </OperatedGuildDetail>
+        <OperatedGuildDetail Icon={FolderSimpleUser}>
+          <EmphasizedData>{guildBase.rolesCount}</EmphasizedData>
+          roles
+        </OperatedGuildDetail>
+        <OperatedGuildDetail Icon={Star}>
+          <EmphasizedData>{rewardCount}</EmphasizedData>
+          rewards in total
+        </OperatedGuildDetail>
+        <OperatedGuildDetail Icon={ShootingStar}>
+          In the top
+          <EmphasizedData>__%</EmphasizedData>
+          of guilds
+        </OperatedGuildDetail>
+        {createdAt && (
+          <OperatedGuildDetail Icon={Calendar}>
+            Created
+            <EmphasizedData>{createdAt}</EmphasizedData>
+            ago
+          </OperatedGuildDetail>
+        )}
+      </div>
+    </Card>
+  )
+}
+
+const OperatedGuildDetail = ({
+  Icon,
+  children,
+}: PropsWithChildren<{ Icon: Icon }>) => (
+  <Card className="flex items-center gap-2 rounded-xl p-4 font-bold shadow md:p-5 dark:bg-secondary">
+    <Icon weight="bold" className="min-w-min" />
+    <span className="text-muted-foreground">{children}</span>
+  </Card>
+)
+
+const EmphasizedData = ({ children }: PropsWithChildren) => (
+  <span className="font-black text-foreground"> {children} </span>
+)

--- a/src/app/(marketing)/profile/_components/Profile.tsx
+++ b/src/app/(marketing)/profile/_components/Profile.tsx
@@ -1,8 +1,8 @@
 "use client"
 import { useWeb3ConnectionManager } from "@/components/Web3ConnectionManager/hooks/useWeb3ConnectionManager"
-import { Badge } from "@/components/ui/Badge"
 import { Card } from "@/components/ui/Card"
 import { ProgressIndicator, ProgressRoot } from "@/components/ui/Progress"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip"
 import { cn } from "@/lib/utils"
 import { Info } from "@phosphor-icons/react"
 import { PropsWithChildren } from "react"
@@ -49,13 +49,16 @@ export const Profile = () => {
             <div className="-mt-1 flex grow flex-col gap-3">
               <div className="flex flex-col justify-between sm:flex-row">
                 <h3 className="font-bold capitalize">{xp.rank.title}</h3>
-                <Badge variant="outline">
-                  {`${xp.currentLevelXp} -> `}
-                  <span className="font-bold text-foreground">
-                    {xp.experienceCount} XP
-                  </span>
-                  {` -> ${xp.nextLevelXp}`}
-                </Badge>
+                <Tooltip>
+                  <TooltipTrigger className="self-end text-muted-foreground text-sm underline decoration-dotted underline-offset-2">
+                    {`${xp.experienceCount} / ${xp.nextLevelXp} XP`}
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {`${xp.currentLevelXp} -> `}
+                    <span className="font-bold">{xp.experienceCount} XP</span>
+                    {` -> ${xp.nextLevelXp}`}
+                  </TooltipContent>
+                </Tooltip>
               </div>
               <ProgressRoot>
                 <ProgressIndicator

--- a/src/app/(marketing)/profile/_components/Profile.tsx
+++ b/src/app/(marketing)/profile/_components/Profile.tsx
@@ -15,6 +15,7 @@ import { useContributions } from "../_hooks/useContributions"
 import { useExperienceProgression } from "../_hooks/useExperienceProgression"
 import { useProfile } from "../_hooks/useProfile"
 import { useReferredUsers } from "../_hooks/useReferredUsers"
+import { selectOperatedGuilds } from "../_utils/selectOperatedGuilds"
 import { ActivityChart } from "./ActivityChart"
 import { LevelBadge } from "./LevelBadge"
 import { OperatedGuild } from "./OperatedGuilds"
@@ -31,10 +32,7 @@ export const Profile = () => {
   let { data: operatedGuilds } = useSWRImmutable<GuildBase[]>(
     profile ? `/v2/guilds?username=${profile.username}` : null
   )
-  operatedGuilds = operatedGuilds
-    ?.filter((guild) => guild.isAdmin)
-    .sort((a, b) => a.memberCount - b.memberCount)
-    .slice(0, 2)
+  operatedGuilds = operatedGuilds && selectOperatedGuilds({ guilds: operatedGuilds })
 
   if (!profile || !contributions || !referredUsers || !xp)
     return <ProfileMainSkeleton />

--- a/src/app/(marketing)/profile/_components/Profile.tsx
+++ b/src/app/(marketing)/profile/_components/Profile.tsx
@@ -79,7 +79,7 @@ export const Profile = () => {
       {!!operatedGuilds?.length && (
         <div className="mb-12">
           <SectionTitle className="mb-3">Operated guilds</SectionTitle>
-          <div className="flex flex-col gap-5">
+          <div className="flex flex-col gap-3">
             {operatedGuilds.map((guild) => (
               <OperatedGuild guildBase={guild} key={guild.id} />
             ))}

--- a/src/app/(marketing)/profile/_components/Profile.tsx
+++ b/src/app/(marketing)/profile/_components/Profile.tsx
@@ -73,7 +73,7 @@ export const Profile = () => {
           </Card>
         </div>
       </div>
-      {operatedGuilds && (
+      {!!operatedGuilds?.length && (
         <div className="mb-12">
           <SectionTitle className="mb-3">Operated guilds</SectionTitle>
           <div className="flex flex-col gap-5">

--- a/src/app/(marketing)/profile/_utils/selectOperatedGuilds.ts
+++ b/src/app/(marketing)/profile/_utils/selectOperatedGuilds.ts
@@ -1,0 +1,10 @@
+import { GuildBase } from "types"
+
+export const selectOperatedGuilds = ({
+  guilds,
+}: { guilds: GuildBase[] }): GuildBase[] => {
+  return guilds
+    .filter((guild) => guild.isAdmin)
+    .sort((a, b) => b.memberCount - a.memberCount)
+    .slice(0, 2)
+}


### PR DESCRIPTION
- **feat: add operated guild cards**
- **chore: remove non-retrievable cards**
- **feat: render operated guilds on server**
- **fix: cache the correct endpoint for operated guilds**
- **chore: adjust experience card**
