### PR TITLE
feat: `IconButton` component & stories

### DIFF
--- a/src/v2/components/ui/IconButton.stories.tsx
+++ b/src/v2/components/ui/IconButton.stories.tsx
@@ -1,0 +1,85 @@
+import { CircleDashed } from "@phosphor-icons/react/dist/ssr"
+import { Meta, StoryObj } from "@storybook/react"
+import { IconButton, IconButtonProps } from "./IconButton"
+
+type IconButtonExampleProps = Omit<IconButtonProps, "icon">
+
+const IconButtonExample = (props: IconButtonExampleProps) => (
+  <IconButton {...props} icon={<CircleDashed weight="bold" />} />
+)
+
+const meta: Meta<typeof IconButtonExample> = {
+  title: "Design system/IconButton",
+  component: IconButtonExample,
+}
+
+export default meta
+
+type Story = StoryObj<typeof IconButton>
+
+export const Solid: Story = {
+  args: {
+    size: "md",
+    variant: "solid",
+    colorScheme: "primary",
+    isLoading: false,
+    disabled: false,
+  },
+  argTypes: {
+    size: {
+      type: "string",
+      control: "select",
+      options: ["sm", "md", "lg"] satisfies IconButtonProps["size"][],
+    },
+    colorScheme: {
+      type: "string",
+      control: "select",
+      options: [
+        "primary",
+        "secondary",
+        "info",
+        "destructive",
+        "success",
+      ] satisfies IconButtonProps["colorScheme"][],
+    },
+    variant: {
+      control: {
+        disable: true,
+      },
+    },
+    disabled: {
+      type: "boolean",
+      control: "boolean",
+    },
+  },
+}
+
+export const Outline: Story = {
+  args: {
+    ...Solid.args,
+    variant: "outline",
+  },
+  argTypes: {
+    ...Solid.argTypes,
+  },
+}
+
+export const Ghost: Story = {
+  args: {
+    ...Solid.args,
+    variant: "ghost",
+  },
+  argTypes: {
+    ...Solid.argTypes,
+  },
+}
+
+export const Subtle: Story = {
+  args: {
+    ...Solid.args,
+    variant: "subtle",
+  },
+  argTypes: {
+    ...Solid.argTypes,
+  },
+}

--- a/src/v2/components/ui/IconButton.stories.tsx
+++ b/src/v2/components/ui/IconButton.stories.tsx
@@ -2,10 +2,14 @@ import { CircleDashed } from "@phosphor-icons/react/dist/ssr"
 import { Meta, StoryObj } from "@storybook/react"
 import { IconButton, IconButtonProps } from "./IconButton"
 
-type IconButtonExampleProps = Omit<IconButtonProps, "icon">
+type IconButtonExampleProps = Omit<IconButtonProps, "aria-label" | "icon">
 
 const IconButtonExample = (props: IconButtonExampleProps) => (
-  <IconButton {...props} icon={<CircleDashed weight="bold" />} />
+  <IconButton
+    {...props}
+    aria-label="IconButton example"
+    icon={<CircleDashed weight="bold" />}
+  />
 )
 
 const meta: Meta<typeof IconButtonExample> = {

--- a/src/v2/components/ui/IconButton.tsx
+++ b/src/v2/components/ui/IconButton.tsx
@@ -19,7 +19,13 @@ const iconButtonVariants = cva("p-0", {
 export interface IconButtonProps
   extends Omit<
       ButtonProps,
-      "size" | "loadingText" | "leftIcon" | "rightIcon" | "asChild" | "children"
+      | "size"
+      | "loadingText"
+      | "leftIcon"
+      | "rightIcon"
+      | "asChild"
+      | "children"
+      | "aria-label"
     >,
     VariantProps<typeof iconButtonVariants> {
   "aria-label": string

--- a/src/v2/components/ui/IconButton.tsx
+++ b/src/v2/components/ui/IconButton.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils"
+import { VariantProps, cva } from "class-variance-authority"
+import { ReactNode, forwardRef } from "react"
+import { Button, ButtonProps } from "./Button"
+
+const iconButtonVariants = cva("p-0", {
+  variants: {
+    size: {
+      sm: "size-8",
+      md: "size-10",
+      lg: "size-12",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+  },
+})
+
+export interface IconButtonProps
+  extends Omit<
+      ButtonProps,
+      "size" | "loadingText" | "leftIcon" | "rightIcon" | "asChild" | "children"
+    >,
+    VariantProps<typeof iconButtonVariants> {
+  "aria-label": string
+  // icon: ButtonProps["leftIcon"] // TODO: uncomment this in the Button refactor PR
+  icon: ReactNode
+}
+
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({ size, icon, className, ...props }, ref) => (
+    <Button
+      ref={ref}
+      {...props}
+      className={cn(iconButtonVariants({ size, className }))}
+    >
+      {icon}
+    </Button>
+  )
+)
+
+export { IconButton }


### PR DESCRIPTION
Implemented this component for 2 reasons:
- We'll refactor the `Button` component & it'll receive left and right icon as a prop, so I'd like to maintain a consistent API for this (we could technically use the button component & pass the icon as a child to it too, but then we'd probably forget to define the `aria-label` attribute, which is important for accessibility)
- I noticed that we have an `icon` and an `icon-sm` size variant in our `Button` component, which in my opinion clearly indicated that we might need a new component for these variants