### PR TITLE
fix: handle loading wallet client

### DIFF
--- a/src/v2/components/Web3ConnectionManager/WalletSelectorModal/WalletSelectorModal.tsx
+++ b/src/v2/components/Web3ConnectionManager/WalletSelectorModal/WalletSelectorModal.tsx
@@ -39,8 +39,13 @@ type Props = {
 }
 
 const WalletSelectorModal = ({ isOpen, onClose }: Props): JSX.Element => {
-  const { isWeb3Connected, isInSafeContext, disconnect, address } =
-    useWeb3ConnectionManager()
+  const {
+    isWeb3Connected,
+    isInSafeContext,
+    disconnect,
+    address,
+    isWalletClientLoading,
+  } = useWeb3ConnectionManager()
 
   const { connectors, error, connect, variables, isPending } = useConnect()
 
@@ -241,9 +246,18 @@ const WalletSelectorModal = ({ isOpen, onClose }: Props): JSX.Element => {
               }}
               disabled={!id && !publicUserError}
               isLoading={
-                linkAddress.isLoading || set.isLoading || (!id && !publicUserError)
+                isWalletClientLoading ||
+                linkAddress.isLoading ||
+                set.isLoading ||
+                (!id && !publicUserError)
               }
-              loadingText={!id ? "Looking for keypairs" : "Check your wallet"}
+              loadingText={
+                isWalletClientLoading
+                  ? "Loading wallet"
+                  : !id
+                    ? "Looking for keypairs"
+                    : "Check your wallet"
+              }
               className="mb-4 w-full"
               data-testid="verify-address-button"
             >

--- a/src/v2/components/Web3ConnectionManager/hooks/useWeb3ConnectionManager.ts
+++ b/src/v2/components/Web3ConnectionManager/hooks/useWeb3ConnectionManager.ts
@@ -8,7 +8,7 @@ import { UserProfile } from "@guildxyz/types"
 import { atom, useAtom } from "jotai"
 import { useEffect } from "react"
 import { parseFuelAddress } from "utils/parseFuelAddress"
-import { useAccount, useDisconnect, useSignMessage } from "wagmi"
+import { useAccount, useDisconnect, useSignMessage, useWalletClient } from "wagmi"
 
 const safeContextAtom = atom(false)
 
@@ -18,7 +18,8 @@ export function useWeb3ConnectionManager(): {
   address?: `0x${string}`
   type: UserProfile["addresses"][number]["walletType"] | null
   disconnect: () => void
-  signMessage: (message: string) => Promise<string>
+  signMessage: (message: string) => Promise<string> | undefined
+  isWalletClientLoading: boolean
 } {
   const [isInSafeContext, setIsInSafeContext] = useAtom(safeContextAtom)
 
@@ -52,6 +53,7 @@ export function useWeb3ConnectionManager(): {
   const { disconnect: disconnectEvm } = useDisconnect()
   const { disconnect: disconnectFuel } = useFuelDisconnect()
 
+  const { data: walletClient } = useWalletClient()
   const { wallet: fuelWallet } = useWallet()
 
   const disconnect = () => {
@@ -64,7 +66,7 @@ export function useWeb3ConnectionManager(): {
     if (type === "EVM") {
       return signMessageAsync({ account: evmAddress, message })
     }
-    return fuelWallet.signMessage(message)
+    return fuelWallet?.signMessage(message)
   }
 
   return {
@@ -74,5 +76,6 @@ export function useWeb3ConnectionManager(): {
     type,
     disconnect,
     signMessage,
+    isWalletClientLoading: !!address && !walletClient && !fuelWallet,
   }
 }


### PR DESCRIPTION
Sometimes the wallet client is still `undefined` when the user clicks on the "Verify address" button, so the users gets on error. This PR aims to handle this edge case.