### PR TITLE
fix: remove old neynar api call

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_API=https://api.guild.xyz/v1
+NEXT_PUBLIC_DOMAIN=https://guild.xyz
 NEXT_PUBLIC_DISCORD_CLIENT_ID=868172385000509460
 NEXT_PUBLIC_IPFS_GATEWAY=https://guild-xyz.mypinata.cloud/ipfs/
 NEXT_PUBLIC_PINATA_API=https://api.pinata.cloud

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_API=https://api.guild.xyz/v1
-NEXT_PUBLIC_DOMAIN=https://guild.xyz
+NEXT_PUBLIC_URL=https://$NEXT_PUBLIC_VERCEL_URL
 NEXT_PUBLIC_DISCORD_CLIENT_ID=868172385000509460
 NEXT_PUBLIC_IPFS_GATEWAY=https://guild-xyz.mypinata.cloud/ipfs/
 NEXT_PUBLIC_PINATA_API=https://api.pinata.cloud

--- a/src/app/(marketing)/profile/[username]/page.tsx
+++ b/src/app/(marketing)/profile/[username]/page.tsx
@@ -7,10 +7,10 @@ import {
   LayoutMain,
 } from "@/components/Layout"
 import { SWRProvider } from "@/components/SWRProvider"
-import {
-  NEYNAR_BASE_URL,
-  NEYNAR_DEFAULT_HEADERS,
-} from "@/hooks/useFarcasterAPI/constants"
+//import {
+//  NEYNAR_BASE_URL,
+//  NEYNAR_DEFAULT_HEADERS,
+//} from "@/hooks/useFarcasterAPI/constants"
 import { FarcasterProfile, Guild, Role, Schemas } from "@guildxyz/types"
 import { env } from "env"
 import { Metadata } from "next"
@@ -80,16 +80,16 @@ const fetchPublicProfileData = async ({
     }
   )
   const fcProfile = farcasterProfiles.at(0)
-  const neynarRequest =
-    fcProfile && new URL(`${NEYNAR_BASE_URL}/user/bulk?fids=${fcProfile.fid}`)
-  const fcFollowers =
-    neynarRequest &&
-    (await ssrFetcher(neynarRequest, {
-      headers: NEYNAR_DEFAULT_HEADERS,
-      next: {
-        revalidate: 12 * 3600,
-      },
-    }))
+  //const neynarRequest =
+  //  fcProfile && new URL(`${NEYNAR_BASE_URL}/user/bulk?fids=${fcProfile.fid}`, api)
+  //const fcFollowers =
+  //  neynarRequest &&
+  //  (await ssrFetcher(neynarRequest, {
+  //    headers: NEYNAR_DEFAULT_HEADERS,
+  //    next: {
+  //      revalidate: 12 * 3600,
+  //    },
+  //  }))
 
   const referredUsersRequest = new URL(
     `/v2/profiles/${username}/referred-users`,
@@ -202,7 +202,7 @@ const fetchPublicProfileData = async ({
         [profileRequest.pathname, profile],
         [contributionsRequest.pathname, contributions],
         [farcasterProfilesRequest.pathname, farcasterProfiles],
-        [neynarRequest?.href, fcFollowers],
+        //[neynarRequest?.href, fcFollowers],
         [referredUsersRequest.pathname, referredUsers],
         [experiencesRequest.pathname, experiences],
         [

--- a/src/app/(marketing)/profile/[username]/page.tsx
+++ b/src/app/(marketing)/profile/[username]/page.tsx
@@ -7,10 +7,10 @@ import {
   LayoutMain,
 } from "@/components/Layout"
 import { SWRProvider } from "@/components/SWRProvider"
-//import {
-//  NEYNAR_BASE_URL,
-//  NEYNAR_DEFAULT_HEADERS,
-//} from "@/hooks/useFarcasterAPI/constants"
+import {
+  NEYNAR_BASE_URL,
+  NEYNAR_DEFAULT_HEADERS,
+} from "@/hooks/useFarcasterAPI/constants"
 import { FarcasterProfile, Guild, Role, Schemas } from "@guildxyz/types"
 import { env } from "env"
 import { Metadata } from "next"
@@ -80,16 +80,20 @@ const fetchPublicProfileData = async ({
     }
   )
   const fcProfile = farcasterProfiles.at(0)
-  //const neynarRequest =
-  //  fcProfile && new URL(`${NEYNAR_BASE_URL}/user/bulk?fids=${fcProfile.fid}`, api)
-  //const fcFollowers =
-  //  neynarRequest &&
-  //  (await ssrFetcher(neynarRequest, {
-  //    headers: NEYNAR_DEFAULT_HEADERS,
-  //    next: {
-  //      revalidate: 12 * 3600,
-  //    },
-  //  }))
+  const neynarRequest =
+    fcProfile &&
+    new URL(
+      `${NEYNAR_BASE_URL}/user/bulk?fids=${fcProfile.fid}`,
+      env.NEXT_PUBLIC_DOMAIN
+    )
+  const fcFollowers =
+    neynarRequest &&
+    (await ssrFetcher(neynarRequest, {
+      headers: NEYNAR_DEFAULT_HEADERS,
+      next: {
+        revalidate: 12 * 3600,
+      },
+    }))
 
   const referredUsersRequest = new URL(
     `/v2/profiles/${username}/referred-users`,
@@ -202,7 +206,7 @@ const fetchPublicProfileData = async ({
         [profileRequest.pathname, profile],
         [contributionsRequest.pathname, contributions],
         [farcasterProfilesRequest.pathname, farcasterProfiles],
-        //[neynarRequest?.href, fcFollowers],
+        [neynarRequest?.pathname, fcFollowers],
         [referredUsersRequest.pathname, referredUsers],
         [experiencesRequest.pathname, experiences],
         [

--- a/src/app/(marketing)/profile/[username]/page.tsx
+++ b/src/app/(marketing)/profile/[username]/page.tsx
@@ -84,7 +84,7 @@ const fetchPublicProfileData = async ({
     fcProfile &&
     new URL(
       `${NEYNAR_BASE_URL}/user/bulk?fids=${fcProfile.fid}`,
-      env.NEXT_PUBLIC_DOMAIN
+      env.NEXT_PUBLIC_URL
     )
   const fcFollowers =
     neynarRequest &&

--- a/src/env.js
+++ b/src/env.js
@@ -30,7 +30,7 @@ export const env = createEnv({
     // Guild APIs
     NEXT_PUBLIC_API: z.string(),
     NEXT_PUBLIC_BALANCY_API: z.string(),
-    NEXT_PUBLIC_DOMAIN: z.string(),
+    NEXT_PUBLIC_URL: z.string(),
 
     // Captcha
     NEXT_PUBLIC_RECAPTCHA_SITE_KEY: z.string(),
@@ -52,7 +52,10 @@ export const env = createEnv({
   },
   runtimeEnv: {
     NEXT_PUBLIC_API: process.env.NEXT_PUBLIC_API,
-    NEXT_PUBLIC_DOMAIN: process.env.NEXT_PUBLIC_DOMAIN,
+    NEXT_PUBLIC_URL:
+      process.env.NODE_ENV === "production"
+        ? process.env.NEXT_PUBLIC_URL
+        : "http://127.0.0.1:3000",
     NEXT_PUBLIC_BALANCY_API: process.env.NEXT_PUBLIC_BALANCY_API,
 
     NEXT_PUBLIC_RECAPTCHA_SITE_KEY: process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY,

--- a/src/env.js
+++ b/src/env.js
@@ -30,6 +30,7 @@ export const env = createEnv({
     // Guild APIs
     NEXT_PUBLIC_API: z.string(),
     NEXT_PUBLIC_BALANCY_API: z.string(),
+    NEXT_PUBLIC_DOMAIN: z.string(),
 
     // Captcha
     NEXT_PUBLIC_RECAPTCHA_SITE_KEY: z.string(),
@@ -51,6 +52,7 @@ export const env = createEnv({
   },
   runtimeEnv: {
     NEXT_PUBLIC_API: process.env.NEXT_PUBLIC_API,
+    NEXT_PUBLIC_DOMAIN: process.env.NEXT_PUBLIC_DOMAIN,
     NEXT_PUBLIC_BALANCY_API: process.env.NEXT_PUBLIC_BALANCY_API,
 
     NEXT_PUBLIC_RECAPTCHA_SITE_KEY: process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY,


### PR DESCRIPTION
### Objective

~~Until the new neynar endpoint is finished, remove the neynar call that causes error on profiles with farcaster~~
Use `guild.xyz` without subdomain for url when requesting neynar.

### Investigation

Error was caused by having a real href swapped by the new neynar route handler (`api/neynar`), which is required by URL constructor

```tsx
const neynarRequest = fcProfile && new URL(`${NEYNAR_BASE_URL}/user/bulk?fids=${fcProfile.fid}`, api)
```

[discord reference](https://discord.com/channels/697041998728659035/1192824841703784498/1293127450141786162)
