### PR TITLE
Blockscout -> Etherscan

### DIFF
--- a/src/static/customChains.ts
+++ b/src/static/customChains.ts
@@ -416,8 +416,8 @@ export const inkSepolia = {
   },
   blockExplorers: {
     default: {
-      name: "Blockscout",
-      url: "https://explorer-sepolia.inkonchain.com",
+      name: "Etherscan",
+      url: "https://sepolia.etherscan.io/",
     },
   },
   contracts: {


### PR DESCRIPTION
Switched from Blockscout to Etherscan, because I experienced issues with Blockscout