### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Open source interface for Guild.xyz -- a tool for platformless membership manage
 
 1. `npm i`
 2. `npm run dev`
-3. If you don't have the secret environment variables, copy the `.env.examples` as `.env.local`.
+3. If you don't have the secret environment variables, copy the `.env.example` as `.env.local`.
 
 Open [http://localhost:3000](http://localhost:3000) in your browser to see the result.
 


### PR DESCRIPTION
<img width="751" alt="Снимок экрана 2024-11-11 в 14 50 05" src="https://github.com/user-attachments/assets/ad71d58b-1d60-44da-89ac-99a2b8c4a69e">

The sentence **"copy the `.env.examples` as `.env.local`"** corrected to **"copy the `.env.example` as `.env.local`"**.

The corrected sentence would be:
> "If you don't have the secret environment variables, copy the `.env.example` as `.env.local`."

Corrected.