### PR TITLE
Leaderboard export improvements

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -25,7 +25,7 @@ export async function GET(req: NextRequest) {
       Object.fromEntries(req.nextUrl.searchParams)
     )
     const leaderboardRequest = new URL(
-      `/v2/guilds/${guildId}/points/${pointsId}/leaderboard?forceRecalculate=true`,
+      `/v2/guilds/${guildId}/points/${pointsId}/leaderboard?forceRecalculate=true&isAllUser=true`,
       env.NEXT_PUBLIC_API
     )
 

--- a/src/components/[guild]/leaderboard/LeaderboardPointsSelector.tsx
+++ b/src/components/[guild]/leaderboard/LeaderboardPointsSelector.tsx
@@ -52,7 +52,17 @@ const LeaderboardPointsSelector = () => {
           <>
             <RecalculateLeaderboardButton size="ICON" />
             <Divider orientation="vertical" h={8} />
-            <Tooltip label="Loading might take a while depending on member count">
+            <Tooltip
+              label={
+                <>
+                  Export leaderboard
+                  <br />
+                  <span style={{ fontSize: "0.9em", opacity: 0.8 }}>
+                    Loading might take a while depending on member count
+                  </span>
+                </>
+              }
+            >
               <a
                 download
                 href={`/api/leaderboard?guildId=${guildId}&pointsId=${router.query.pointsId}`}

--- a/src/components/[guild]/leaderboard/LeaderboardPointsSelector.tsx
+++ b/src/components/[guild]/leaderboard/LeaderboardPointsSelector.tsx
@@ -52,7 +52,7 @@ const LeaderboardPointsSelector = () => {
           <>
             <RecalculateLeaderboardButton size="ICON" />
             <Divider orientation="vertical" h={8} />
-            <Tooltip label="Loading might take a while, depeding on member count">
+            <Tooltip label="Loading might take a while depending on member count">
               <a
                 download
                 href={`/api/leaderboard?guildId=${guildId}&pointsId=${router.query.pointsId}`}

--- a/src/components/common/Layout/components/Footer.tsx
+++ b/src/components/common/Layout/components/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = (): JSX.Element => (
         <Icon as={ArrowSquareOut} ml="1" />
       </Link>
       <Text as="span" colorScheme="gray" lineHeight={2}>
-        {`, and built on the `}
+        {` and built on the `}
       </Text>
       <Link href="https://www.npmjs.com/package/@guildxyz/sdk" isExternal>
         Guild SDK


### PR DESCRIPTION
- export all users, not just the top 500
- fix typo in the export button's tooltip
- adjust the tooltip so it actually says it's an export button
- boy scout: remove unnecessary comma from the footer (again)