### PR TITLE
fix: handle `undefined` fallback data

### DIFF
--- a/src/pages/[guild]/[group].tsx
+++ b/src/pages/[guild]/[group].tsx
@@ -131,7 +131,7 @@ const GroupPageWrapper = ({ groupUrlName, fallback }: Props): JSX.Element => {
     )
   }
 
-  const [fallbackGuild] = Object.values(fallback)
+  const [fallbackGuild] = Object.values(fallback ?? {})
   const fallbackGroup = fallbackGuild?.groups.find((g) => (g.urlName = groupUrlName))
 
   return (


### PR DESCRIPTION
This PR aims to solve a client-side error that occurs when the client doesn't receive fallback data